### PR TITLE
fix: handle when browser tracking is not configured

### DIFF
--- a/samples/Relewise.Umbraco.Application/Relewise.Umbraco.Application.csproj
+++ b/samples/Relewise.Umbraco.Application/Relewise.Umbraco.Application.csproj
@@ -19,10 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Relewise.Client.Extensions" Version="1.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Integrations.Umbraco\Integrations.Umbraco.csproj" />
   </ItemGroup>
 

--- a/samples/Relewise.Umbraco.Application/Relewise.Umbraco.Application.csproj
+++ b/samples/Relewise.Umbraco.Application/Relewise.Umbraco.Application.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Relewise.Client.Extensions" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Integrations.Umbraco\Integrations.Umbraco.csproj" />
   </ItemGroup>
 

--- a/samples/UmbracoV10/Relewise.UmbracoV10.csproj
+++ b/samples/UmbracoV10/Relewise.UmbracoV10.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
 	    <PackageReference Include="Relewise.Client" Version="1.10.0" />
-	    <PackageReference Include="Relewise.Client.Extensions" Version="1.1.0" />
+	    <PackageReference Include="Relewise.Client.Extensions" Version="1.2.0" />
         <PackageReference Include="Umbraco.Cms" Version="10.0.0" />
         <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.0.0" />
     </ItemGroup>

--- a/samples/UmbracoV9/Relewise.UmbracoV9.csproj
+++ b/samples/UmbracoV9/Relewise.UmbracoV9.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
 	    <PackageReference Include="Relewise.Client" Version="1.10.0" />
-	    <PackageReference Include="Relewise.Client.Extensions" Version="1.1.0" />
+	    <PackageReference Include="Relewise.Client.Extensions" Version="1.2.0" />
         <PackageReference Include="Umbraco.Cms" Version="9.4.3" />
     </ItemGroup>
 

--- a/samples/UmbracoV9/Views/Shared/_Layout.cshtml
+++ b/samples/UmbracoV9/Views/Shared/_Layout.cshtml
@@ -7,12 +7,21 @@
 @inject IRelewiseClientFactory RelewiseClientFactory;
 
 @{
-    var breadcrumb = Model.Breadcrumbs(andSelf: true).ToArray();
-    var homePage = breadcrumb.First();
+    IPublishedContent[] breadcrumb = Model.Breadcrumbs(andSelf: true).ToArray();
+    IPublishedContent homePage = breadcrumb.First();
     IEnumerable<IPublishedElement> footer = homePage.Value<IEnumerable<IPublishedElement>>("footerLinks").EmptyIfNull();
     IEnumerable<Link> headerLinks = homePage.Value<IEnumerable<Link>>("headerLinks").EmptyIfNull();
 
-    RelewiseClientOptions tracker = RelewiseClientFactory.GetOptions<ITracker>("Browser");
+    RelewiseClientOptions tracker = null;
+    try
+    {
+        tracker = RelewiseClientFactory.GetOptions<ITracker>("Browser");
+    }
+    catch (ArgumentException)
+    {
+        // Client not found - ignore error
+        // Note: this will be replaced by a call to a future Contains()-method on the client factory.
+    }
 }
 
 <!DOCTYPE html>
@@ -45,9 +54,12 @@
     <link rel="stylesheet" type="text/css" href="/css/util.css">
     <!--===============================================================================================-->
     
-    <script language="javascript">
-        window.__tracker = { "datasetId": "@tracker.DatasetId", "apiKey": "@tracker.ApiKey" }
-    </script>
+    @if (tracker != null)
+    {
+        <script language="javascript">
+            window.__tracker = { "datasetId": "@tracker.DatasetId", "apiKey": "@tracker.ApiKey" }
+        </script>
+    }
 </head>
 <body class="animsition">
 

--- a/samples/UmbracoV9/Views/Shared/_Layout.cshtml
+++ b/samples/UmbracoV9/Views/Shared/_Layout.cshtml
@@ -12,15 +12,10 @@
     IEnumerable<IPublishedElement> footer = homePage.Value<IEnumerable<IPublishedElement>>("footerLinks").EmptyIfNull();
     IEnumerable<Link> headerLinks = homePage.Value<IEnumerable<Link>>("headerLinks").EmptyIfNull();
 
-    RelewiseClientOptions tracker = null;
-    try
+    RelewiseClientOptions trackerOptions = null;
+    if (RelewiseClientFactory.Contains<ITracker>("Browser"))
     {
-        tracker = RelewiseClientFactory.GetOptions<ITracker>("Browser");
-    }
-    catch (ArgumentException)
-    {
-        // Client not found - ignore error
-        // Note: this will be replaced by a call to a future Contains()-method on the client factory.
+        trackerOptions = RelewiseClientFactory.GetOptions<ITracker>("Browser");
     }
 }
 
@@ -53,11 +48,10 @@
     <!--=========================================/======================================================-->
     <link rel="stylesheet" type="text/css" href="/css/util.css">
     <!--===============================================================================================-->
-    
-    @if (tracker != null)
+    @if (trackerOptions != null)
     {
         <script language="javascript">
-            window.__tracker = { "datasetId": "@tracker.DatasetId", "apiKey": "@tracker.ApiKey" }
+            window.__tracker = { "datasetId": "@trackerOptions.DatasetId", "apiKey": "@trackerOptions.ApiKey" }
         </script>
     }
 </head>
@@ -111,7 +105,7 @@
             <div class="btn-show-menu">
                 <!-- Header Icon mobile -->
                 <div class="header-icons-mobile">
- 
+
                     <span class="linedivide2"></span>
 
                     <span id="mini-basket-mobile"></span>
@@ -146,7 +140,7 @@
     {
         IPublishedContent last = breadcrumb.Last();
         <div class="container bread-crumb bgwhite flex-w p-r-15 p-t-10 p-b-15 p-l-15-sm">
-            
+
             @foreach (var content in breadcrumb)
             {
                 <a href="@content.Url()" class="s-text16">
@@ -154,8 +148,9 @@
                 </a>
 
                 if (!last.Equals(content))
-                {<span class="s-text16"><i class=" fa fa-angle-right m-l-8 m-r-9" aria-hidden="true"></i></span>
-                    
+                {
+                    <span class="s-text16"><i class=" fa fa-angle-right m-l-8 m-r-9" aria-hidden="true"></i></span>
+
                 }
             }
 
@@ -265,19 +260,19 @@
     <script type="text/javascript" src="/vendor/jquery/jquery-3.2.1.min.js"></script>
     <!--================================/===============================================================-->
     <script type="text/javascript" src="/vendor/animsition/js/animsition.min.js"></script>
-    <!--================================/===============================================================--> 
+    <!--================================/===============================================================-->
     <script type="text/javascript" src="/vendor/bootstrap/js/popper.js"></script>
     <script type="text/javascript" src="/vendor/bootstrap/js/bootstrap.min.js"></script>
     <!--================================/===============================================================-->
     <script type="text/javascript" src="/vendor/select2/select2.min.js"></script>
-<!--===============================================================================================-->
+    <!--===============================================================================================-->
     <script type="text/javascript" src="/vendor/slick/slick.min.js"></script>
     <script type="text/javascript" src="/js/slick-custom.js"></script>
     <script type="text/javascript" src="/vendor/sweetalert/sweetalert.min.js"></script>
 
-<!--===============================================================================================-->
+    <!--===============================================================================================-->
     <script src="/js/main.js"></script>
-	<script type="module" src="http://localhost:9292/js/chunk-vendors.js"></script>
+    <script type="module" src="http://localhost:9292/js/chunk-vendors.js"></script>
     <script type="module" src="http://localhost:9292/js/app.js"></script>
 
 </body>

--- a/samples/UmbracoV9/client/src/services/tracking.service.ts
+++ b/samples/UmbracoV9/client/src/services/tracking.service.ts
@@ -3,57 +3,85 @@ import { ILineItem } from './basket.service'
 import cookieConsentService from './cookie-consent.service'
 
 class TrackingService {
+  private readonly tracker: Tracker|null = null;
+  private readonly NoTrackerWarning = "Warning: The 'Browser' tracker is missing - This could be due to missing configuration in appSettings";
+
+  constructor () {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private readonly tracker = new Tracker((window as any).__tracker.datasetId, (window as any).__tracker.apiKey);
+    const trackerConfig = (window as any).__tracker
+    if (trackerConfig) {
+      this.tracker = new Tracker(trackerConfig.datasetId, trackerConfig.apiKey)
+    }
+  }
 
-    public trackProductCategoryView (id: string) {
-      this.tracker.trackProductCategoryView({ idPath: [id], user: this.getUser() })
+  public trackProductCategoryView (id: string) {
+    if (this.tracker === null) {
+      console.warn(this.NoTrackerWarning)
+      return
     }
 
-    public async trackProductView (id: string) {
-      this.tracker.trackProductView({ productId: id, user: this.getUser() })
+    this.tracker.trackProductCategoryView({ idPath: [id], user: this.getUser() })
+  }
+
+  public async trackProductView (id: string) {
+    if (this.tracker === null) {
+      console.warn(this.NoTrackerWarning)
+      return
     }
 
-    public async trackCart (lineItems: ILineItem[]) {
-      const items = lineItems.map(x => ({
-        productId: x.product.productId ?? '',
-        quantity: x.quantity,
-        lineTotal: x.quantity * (x.product.salesPrice ?? 0)
-      }))
-      const subTotal = items.reduce((total, i) => total + i.lineTotal, 0)
+    this.tracker.trackProductView({ productId: id, user: this.getUser() })
+  }
 
-      this.tracker.trackCart({
-        lineItems: items,
-        subtotal: { currency: 'USD', amount: subTotal },
-        user: this.getUser()
-      })
+  public async trackCart (lineItems: ILineItem[]) {
+    if (this.tracker === null) {
+      console.warn(this.NoTrackerWarning)
+      return
     }
 
-    public async trackOrder (lineItems: ILineItem[]) {
-      const items = lineItems.map(x => ({
-        productId: x.product.productId ?? '',
-        quantity: x.quantity,
-        lineTotal: x.quantity * (x.product.salesPrice ?? 0)
-      }))
-      const subTotal = items.reduce((total, i) => total + i.lineTotal, 0)
+    const items = lineItems.map(x => ({
+      productId: x.product.productId ?? '',
+      quantity: x.quantity,
+      lineTotal: x.quantity * (x.product.salesPrice ?? 0)
+    }))
+    const subTotal = items.reduce((total, i) => total + i.lineTotal, 0)
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const trackingNumberGenerator = (crypto as any)
-      await this.tracker.trackOrder({
-        lineItems: items,
-        subtotal: { currency: 'USD', amount: subTotal },
-        user: this.getUser(),
-        trackingNumber: trackingNumberGenerator.randomUUID()
-      })
+    this.tracker.trackCart({
+      lineItems: items,
+      subtotal: { currency: 'USD', amount: subTotal },
+      user: this.getUser()
+    })
+  }
+
+  public async trackOrder (lineItems: ILineItem[]) {
+    if (this.tracker === null) {
+      console.warn(this.NoTrackerWarning)
+      return
     }
 
-    private getUser (): User {
-      const userId = cookieConsentService.userIdIfHasConsent
+    const items = lineItems.map(x => ({
+      productId: x.product.productId ?? '',
+      quantity: x.quantity,
+      lineTotal: x.quantity * (x.product.salesPrice ?? 0)
+    }))
+    const subTotal = items.reduce((total, i) => total + i.lineTotal, 0)
 
-      return userId !== null
-        ? UserFactory.byTemporaryId(userId)
-        : UserFactory.anonymous()
-    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const trackingNumberGenerator = (crypto as any)
+    await this.tracker.trackOrder({
+      lineItems: items,
+      subtotal: { currency: 'USD', amount: subTotal },
+      user: this.getUser(),
+      trackingNumber: trackingNumberGenerator.randomUUID()
+    })
+  }
+
+  private getUser (): User {
+    const userId = cookieConsentService.userIdIfHasConsent
+
+    return userId !== null
+      ? UserFactory.byTemporaryId(userId)
+      : UserFactory.anonymous()
+  }
 }
 
 export default new TrackingService()

--- a/src/Integrations.Umbraco/Integrations.Umbraco.csproj
+++ b/src/Integrations.Umbraco/Integrations.Umbraco.csproj
@@ -24,7 +24,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Relewise.Client" Version="1.10.0" />
-		<PackageReference Include="Relewise.Client.Extensions" Version="1.1.0" />
+		<PackageReference Include="Relewise.Client.Extensions" Version="1.2.0" />
 		<PackageReference Include="Umbraco.Cms.Web.BackOffice" version="[9.0.0,11)" />
 		<PackageReference Include="Umbraco.Cms.Web.Common" version="[9.0.0,11)" />
 	</ItemGroup>


### PR DESCRIPTION
@mzanoni - hvis der ikke er indstillet en named-client `Browser`, så falder sitet sammen. 
Jeg har midlertidigt fikset `_Layout.cshtml` - men den bør ændres til at bruge `.Contains`-metoden, når denne er tilgængelig på vores SDK-Extensions.

Men - og det er her jeg tror, at du er manden for at løse det, dét der mangles er at håndtere det pænt inde i `tracking.service.ts`, hvor den læser fra `window`-instansen.

Vil du drible den i mål?