### PR TITLE
chore: upgrade dependencies (202607)

### DIFF
--- a/.agents/skills/upgrade-dependencies/SKILL.md
+++ b/.agents/skills/upgrade-dependencies/SKILL.md
@@ -81,9 +81,10 @@ Preserve existing dependency declaration styles.
 NuGet rules:
 
 - If a package uses NuGet range syntax with brackets or parentheses, keep it as a range.
-- For lower-bound ranges such as `[17.0.0,18)`, only bump the lower bound when upgrading; keep the existing upper bound and bracket/parenthesis style.
+- For lower-bound ranges such as `[17.0.0,18)`, keep the existing lower bound unless the package project genuinely requires a newer minimum version because of direct API usage, compatibility fixes, security policy, or another explicit reason. If a lower bound must be raised, keep the existing upper bound and bracket/parenthesis style.
 - Do not convert ranged package references to pinned versions.
 - For exact versions in sample projects, update to exact versions unless the existing declaration is already a range.
+- For `Relewise.Client` and `Relewise.Client.Extensions` in the package project, prefer the minimum needed supported version over the latest available version. Only raise the lower bound when the integration code requires newer client APIs or fixes, and document that reason in the PR body.
 
 npm rules:
 
@@ -98,8 +99,8 @@ Record skipped or preserved ranged dependencies in both the PR body and final ou
 Upgrade Umbraco deliberately as one compatible set.
 
 - Treat all `Umbraco.Cms*` NuGet packages as a coordinated group.
-- In `src/Integrations.Umbraco/Integrations.Umbraco.csproj`, preserve the package project's compatibility range. For example, `[17.0.0,18)` should become `[17.x.y,18)` when upgrading within Umbraco 17, not `17.x.y` and not `[17.x.y,19)`.
-- In `samples/Umbraco/Umbraco.csproj`, keep exact Umbraco package versions exact and align all sample Umbraco packages to the same target version.
+- In `src/Integrations.Umbraco/Integrations.Umbraco.csproj`, preserve the package project's compatibility range and do not raise the lower bound just because the sample or validation target is upgraded. For example, keep `[17.0.0,18)` as `[17.0.0,18)` unless package code needs a newer minimum; do not change it to `17.x.y`, `[17.x.y,18)`, or `[17.x.y,19)` without a concrete compatibility reason.
+- In `samples/Umbraco/Umbraco.csproj`, keep exact Umbraco package versions exact and align all sample Umbraco packages to the same target version. The sample project is only a validation/sample host and must not drive the package project's minimum supported Umbraco version.
 - Keep `@umbraco-cms/backoffice` in `src/Integrations.Umbraco/Client/package.json` in its existing declaration style. If it is `^*`, do not change it.
 - After an Umbraco upgrade, inspect compile errors for breaking API changes and fix compatibility issues that are direct consequences of the upgrade.
 - Keep package metadata aligned when relevant, including `PackageTags` and `umbraco-marketplace.json`, but do not change supported-major claims unless the dependency upgrade actually changes the supported Umbraco major.

--- a/.agents/skills/upgrade-dependencies/SKILL.md
+++ b/.agents/skills/upgrade-dependencies/SKILL.md
@@ -104,6 +104,9 @@ Upgrade Umbraco deliberately as one compatible set.
 - Keep `@umbraco-cms/backoffice` in `src/Integrations.Umbraco/Client/package.json` in its existing declaration style. If it is `^*`, do not change it.
 - After an Umbraco upgrade, inspect compile errors for breaking API changes and fix compatibility issues that are direct consequences of the upgrade.
 - Keep package metadata aligned when relevant, including `PackageTags` and `umbraco-marketplace.json`, but do not change supported-major claims unless the dependency upgrade actually changes the supported Umbraco major.
+- When a new Umbraco major is released and the goal is to support it if compatible, update the sample project to the latest patch of that new major and run the full validation suite. If validation passes without package-code compatibility fixes, expand the package project's upper-bound range to include that major while preserving the existing lower bound; for example `[17.0.0,18)` can become `[17.0.0,19)` after validating Umbraco 18.
+- When expanding supported Umbraco majors, update NuGet `PackageTags` with the new `Umbraco-vN` tag and update `umbraco-marketplace.json` tags or version metadata when present so marketplace support signals match the package dependency range.
+- Record whether the new major was validated only through the sample project or also required package-code fixes. If fixes were required, summarize them and keep the widened range only when the fixed package builds successfully against the new major.
 
 If the user asks for a major Umbraco upgrade, confirm the target major and adjust ranges consistently before proceeding.
 

--- a/samples/Umbraco/Umbraco.csproj
+++ b/samples/Umbraco/Umbraco.csproj
@@ -8,8 +8,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Umbraco.Cms" Version="17.0.2" />
-		<PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.0.2" />
+		<PackageReference Include="Umbraco.Cms" Version="17.5.3" />
+		<PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.5.3" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -30,13 +30,12 @@
 		<RazorCompileOnPublish>false</RazorCompileOnPublish>
 	</PropertyGroup>
 
-
-	<ItemGroup>
-		<AppClientFiles Include="..\..\src\Integrations.Umbraco\App_Plugins\**\*" />
-	</ItemGroup>
 	<Target Name="CopyCommonContent" AfterTargets="Build" Inputs="..\..\src\Integrations.Umbraco\obj\Debug\net10.0\client.complete.txt"
 	        Outputs="obj\client.copied.txt">
 		<Message Text="Copying App Client Files" Importance="high" />
+		<ItemGroup>
+			<AppClientFiles Include="..\..\src\Integrations.Umbraco\App_Plugins\**\*" />
+		</ItemGroup>
 		<Copy SourceFiles="@(AppClientFiles)" DestinationFiles="wwwroot\App_Plugins\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" OverwriteReadOnlyFiles="true" />
 	</Target>
 

--- a/samples/Umbraco/Umbraco.csproj
+++ b/samples/Umbraco/Umbraco.csproj
@@ -8,8 +8,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Umbraco.Cms" Version="17.5.3" />
-		<PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.5.3" />
+		<PackageReference Include="Umbraco.Cms" Version="18.0.2" />
+		<PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="18.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Integrations.Umbraco/Client/package-lock.json
+++ b/src/Integrations.Umbraco/Client/package-lock.json
@@ -8,420 +8,72 @@
       "name": "relewise-dashboard",
       "version": "0.0.0",
       "devDependencies": {
-        "@hey-api/client-fetch": "^0.10.0",
-        "@hey-api/openapi-ts": "0.80.5",
+        "@hey-api/client-fetch": "^0.13.1",
+        "@hey-api/openapi-ts": "0.99.0",
         "@umbraco-cms/backoffice": "^*",
-        "chalk": "5.5.0",
-        "cross-env": "^7.0.3",
+        "chalk": "5.6.2",
+        "cross-env": "^10.1.0",
         "node-fetch": "^3.3.2",
-        "typescript": "^5.8.3",
-        "vite": "^6.3.4"
+        "typescript": "^6.0.3",
+        "vite": "^8.1.3"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@heximal/expressions": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@heximal/expressions/-/expressions-0.1.5.tgz",
+      "integrity": "sha512-QdWz9vNrdzi24so9KGEM9w4UYLg1yk+LVvYBEDbw9EY1BzKHITWdtYc55xJ3Zuio0/9Naz/D1YtYlCnfsycNDQ==",
       "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "license": "BSD 3-Clause",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/@hey-api/client-fetch": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@hey-api/client-fetch/-/client-fetch-0.10.2.tgz",
-      "integrity": "sha512-AGiFYDx+y8VT1wlQ3EbzzZtfU8EfV+hLLRTtr8Y/tjYZaxIECwJagVZf24YzNbtEBXONFV50bwcU1wLVGXe1ow==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/client-fetch/-/client-fetch-0.13.1.tgz",
+      "integrity": "sha512-29jBRYNdxVGlx5oewFgOrkulZckpIpBIRHth3uHFn1PrL2ucMy52FvWOY3U3dVx2go1Z3kUmMi6lr07iOpUqqA==",
       "deprecated": "Starting with v0.73.0, this package is bundled directly inside @hey-api/openapi-ts.",
       "dev": true,
       "license": "MIT",
@@ -432,53 +84,116 @@
         "@hey-api/openapi-ts": "< 2"
       }
     },
-    "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.0.6.tgz",
-      "integrity": "sha512-yktiFZoWPtEW8QKS65eqKwA5MTKp88CyiL8q72WynrBs/73SAaxlSWlA2zW/DZlywZ5hX1OYzrCC0wFdvO9c2w==",
+    "node_modules/@hey-api/codegen-core": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
+      "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21"
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "c12": "3.3.4",
+        "color-support": "1.1.3"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/json-schema-ref-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
+      "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "7.1.3",
+        "@types/json-schema": "7.0.15",
+        "js-yaml": "4.2.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.80.5",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.80.5.tgz",
-      "integrity": "sha512-2cX/NooOT8qiP5dR+XjKGjVQByNlRFvw4j2KV2ur1UPssdyAlLbKyWD/YAALqncLR+j4+FD9z/Ich66IQsK8pw==",
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
+      "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hey-api/json-schema-ref-parser": "1.0.6",
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/shared": "0.5.0",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "@lukeed/ms": "2.0.2",
         "ansi-colors": "4.1.3",
-        "c12": "2.0.1",
         "color-support": "1.1.3",
-        "commander": "13.0.0",
-        "handlebars": "4.7.8",
-        "open": "10.1.2",
-        "semver": "7.7.2"
+        "commander": "15.0.0",
+        "get-tsconfig": "4.14.0"
       },
       "bin": {
-        "openapi-ts": "bin/index.cjs"
+        "openapi-ts": "bin/run.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=22.10.0"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       },
       "peerDependencies": {
-        "typescript": "^5.5.3"
+        "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc"
       }
+    },
+    "node_modules/@hey-api/shared": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
+      "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "cross-spawn": "7.0.6",
+        "open": "11.0.0",
+        "semver": "7.8.4"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/spec-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
+      "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hey-api/types": "0.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/types": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
+      "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
@@ -488,774 +203,831 @@
       "license": "MIT"
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
-      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/@lit/reactive-element": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.0.tgz",
-      "integrity": "sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
-    "node_modules/@remirror/core-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
       "dev": true,
-      "peer": true
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz",
-      "integrity": "sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@microsoft/signalr": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.0.tgz",
+      "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
       "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
+      }
+    },
+    "node_modules/@microsoft/signalr/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.1.tgz",
-      "integrity": "sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.1.tgz",
-      "integrity": "sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.1.tgz",
-      "integrity": "sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.1.tgz",
-      "integrity": "sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.1.tgz",
-      "integrity": "sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.1.tgz",
-      "integrity": "sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.1.tgz",
-      "integrity": "sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.1.tgz",
-      "integrity": "sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.1.tgz",
-      "integrity": "sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.1.tgz",
-      "integrity": "sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.1.tgz",
-      "integrity": "sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.1.tgz",
-      "integrity": "sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==",
-      "cpu": [
-        "riscv64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.1.tgz",
-      "integrity": "sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.1.tgz",
-      "integrity": "sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.1.tgz",
-      "integrity": "sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.1.tgz",
-      "integrity": "sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.1.tgz",
-      "integrity": "sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
-        "win32"
-      ]
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.1.tgz",
-      "integrity": "sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
-        "ia32"
+        "wasm32"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.1.tgz",
-      "integrity": "sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tiptap/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-zN+NFFxLsxNEL8Qioc+DL6b8+Tt2bmRbXH22Gk6F6nD30x83eaUSFlSv3wqvgyCq3I1i1NO394So+Agmayx6rQ==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.3.tgz",
+      "integrity": "sha512-TJj5929M96C1KlH796wS8MywfHDh49RhmakOyzyMMc9pFmRj9UXi1gj0TCXgsZtjEOG7B+m/DRvNOvnuvR9kmg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/pm": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.23.1.tgz",
-      "integrity": "sha512-GI3s+uFU88LWRaDG20Z9yIu2av3Usn8kw2lkm2ntwX1K6/mQBS/zkGhWr/FSwWOlMtTzYFxF4Ttb0e+hn67A/A==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.27.3.tgz",
+      "integrity": "sha512-VGoVMcqcGkkoduzEqQ70ZK5OOHBDn5iYeHJSgkvNoSHzYHl0CaKoWxoDKJjSWC5DAM4mBU+tXTlsiUp3evRMfA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.23.1.tgz",
-      "integrity": "sha512-OM4RxuZeOqpYRN1G/YpXSE8tZ3sVtT2XlO3qKa74qf+htWz8W3x4X0oQCrHrRTDSAA1wbmeZU3QghAIHnbvP/A==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.27.3.tgz",
+      "integrity": "sha512-pchbycFppBqBmvk+OxrQLIPZLNd3rNbcm7zOa+OTjluphpAcsJ6AmHBmiRhJUYWitV6/SA+0nujcaWxBp5hNcQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.23.1.tgz",
-      "integrity": "sha512-0g9U42m+boLJZP3x9KoJHDCp9WD5abaVdqNbTg9sFPDNsepb7Zaeu8AEB+yZLP/fuTI1I4ko6qkdr3UaaIYcmA==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.27.3.tgz",
+      "integrity": "sha512-owQW6mcgnYgQU1z5BqmslcjZFBUm1SGM/Ax++4R6XelIt/7ol6uSTjzjAzum+ASW7UlBbuJHuSgRjl8cA+RGkg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-character-count": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-character-count/-/extension-character-count-2.11.7.tgz",
-      "integrity": "sha512-gcVbKou+uxzg8N0BBKceLwtpWvN8g2TIjTuCdyAcAPukX63DqVWOkofFHn1RqZbstJmtF4pTGZs9OH/GJrp27Q==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/extension-list": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.23.1.tgz",
-      "integrity": "sha512-3IOdE40m0UTR2+UXui69o/apLtutAbtzfgmMxD6q0qlRvVqz99QEfk9RPHDNlUqJtYCL4TD+sj7UclBsDdgVXA==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.27.3.tgz",
+      "integrity": "sha512-T7JF10Y3k7fyVujXXLVubdUh7fctgBUoiuxbvjotpltg1U/mPbOcT0UW/uif9j3H8TFvAwNApVw3x8bwwFUakA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.23.1.tgz",
-      "integrity": "sha512-eYzJVUR13BhSE/TYAMZihGBId+XiwhnTPqGcSFo+zx89It/vxwDLvAUn0PReMNI7ULKPTw8orUt2fVKSarb2DQ==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.3.tgz",
+      "integrity": "sha512-3CVnzkpGoqqI5KaXI9l9PMwLkx34SYY63tpeo0I0QjDk4LU+JTAQDTPJFSwB4zTsHZ7ZFMU0jjasFOZ1kZRVgw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.27.3",
+        "@tiptap/pm": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.23.1.tgz",
-      "integrity": "sha512-2nkIkGVsaMJkpd024E6vXK+5XNz8VOVWp/pM6bbXpuv0HnGPrfLdh4ruuFc+xTQ3WPOmpSu8ygtujt4I1o9/6g==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.27.3.tgz",
+      "integrity": "sha512-PR25MRv56Nm4ETVLwA8nAh/0RrVdvD4D2nxnAC8kUkxz1WOYDaqTfPqqEeSWDoUUTUp1I1xzDkD4x0gEnAlmZA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.23.1.tgz",
-      "integrity": "sha512-GyVp+o/RVrKlLdrQvtIpJGphFGogiPjcPCkAFcrfY1vDY1EYxfVZELC96gG1mUT1BO8FUD3hmbpkWi9l8/6O4A==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.27.3.tgz",
+      "integrity": "sha512-XsL0Ziual+ynXyx5JgLb0KIOShlMN3MW7+GQvf9PGRb1vOB7IOTRFDxMPrxDWcFIZ6WWMWSrbkCLOKHStt1BWg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/extensions": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.23.1.tgz",
-      "integrity": "sha512-iP+TiFIGZEbOvYAs04pI14mLI4xqbt64Da91TgMF1FNZUrG+9eWKjqbcHLQREuK3Qnjn5f0DI4nOBv61FlnPmA==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.27.3.tgz",
+      "integrity": "sha512-MVBqzwYrDOttkn2GOrvvKTDCymfSS2VGSKpahcKKhge5mweSDiqko2X1vBDnMF8aVW3WxIFfDMmO4VMmh8HDZA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/extensions": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.23.1.tgz",
-      "integrity": "sha512-YF66EVxnBxt1bHPx6fUUSSXK1Vg+/9baJ0AfJ12hCSPCgSjUclRuNmWIH5ikVfByOmPV1xlrN9wryLoSEBcNRQ==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.27.3.tgz",
+      "integrity": "sha512-cySObJITR2CRrWII87mI2LJ12wEETTnxt2p1vvC6ZtUmKnB50fOu+ux8ZEt6KYNocIOtrEZthNFzTOx7R7UtrQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.23.1.tgz",
-      "integrity": "sha512-5BPoli9wudiAOgSyK8309jyRhFyu5vd02lNChfpHwxUudzIJ/L+0E6FcwrDcw+yXh23cx7F5SSjtFQ7AobxlDQ==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.27.3.tgz",
+      "integrity": "sha512-QHXnsNic6iId8pnsFZ8z4PkX5L+HCHa/D7rAi3nNWtPlSIAOxo4nKrALcB5/tHmY+XL8kEXKH3nsNLNEDLCYPg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-history": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.23.1.tgz",
-      "integrity": "sha512-1rp2CRjM+P58oGEgeUUDSk0ch67ngIGbGJOOjiBGKU9GIVhI2j4uSwsYTAa9qYMjMUI6IyH1xJpsY2hLKcBOtg==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.23.1.tgz",
-      "integrity": "sha512-uHEF0jpmhtgAxjKw8/s5ipEeTnu99f9RVMGAlmcthJ5Fx9TzH0MvtH4dtBNEu5MXC7+0bNsnncWo125AAbCohg==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.27.3.tgz",
+      "integrity": "sha512-sNCuo0+Q001B5XTVWY+ULpWXQqtBNRmAqXxAexZl44bx3rDqHG8OzjwT4EM0LIj2+BYVbdqwaJ1vfQbZVEEbig==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.27.3",
+        "@tiptap/pm": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-image": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-2.11.7.tgz",
-      "integrity": "sha512-YvCmTDB7Oo+A56tR4S/gcNaYpqU4DDlSQcRp5IQvmQV5EekSe0lnEazGDoqOCwsit9qQhj4MPQJhKrnaWrJUrg==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.27.3.tgz",
+      "integrity": "sha512-3OVLRH54Xkh9yrI5oGIempuqZkhLG1plyJBRnapx0N8j9IjEImOLF78kPYoAZzaBuU78M3Zk/E7HQZgmnaNRBg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.23.1.tgz",
-      "integrity": "sha512-a+cPzffaC/1AKMmZ1Ka6l81xmTgcalf8NXfBuFCUTf5r7uI9NIgXnLo9hg+jR9F4K+bwhC4/UbMvQQzAjh0c0A==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.27.3.tgz",
+      "integrity": "sha512-7VpVi2vn8kGFAc/HLrt96J/E6+LXOGKn8xLhJS863t150yLIG3EPQLA1h+G5O6eo+/w+9YokvJAAJoeDihj1Jg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.11.7.tgz",
-      "integrity": "sha512-qKIowE73aAUrnQCIifYP34xXOHOsZw46cT/LBDlb0T60knVfQoKVE4ku08fJzAV+s6zqgsaaZ4HVOXkQYLoW7g==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.27.3.tgz",
+      "integrity": "sha512-iXmu1tJ/3vP60c9d+zfO3+X64vod2EyBrM1qeufecAtWA6t0bT9tYeka0Zq6qDRGsZK5zViO9F2lsY7eHXiYuA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "linkifyjs": "^4.2.0"
+        "linkifyjs": "^4.3.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.27.3",
+        "@tiptap/pm": "3.27.3"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.3.tgz",
+      "integrity": "sha512-52rcaSzYjtVGUrNkdB8k1Bw/rId2lBirrWMvmnBLsieoeFd8zo8ow5zkwV057BYSgWXfnMAV7GOpDyq2IoSD9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.3",
+        "@tiptap/pm": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.23.1.tgz",
-      "integrity": "sha512-wVrRp6KAiyjFVFGmn+ojisP64Bsd+ZPdqQBYVbebBx1skZeW0uhG60d7vUkWHi0gCgxHZDfvDbXpfnOD0INRWw==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.27.3.tgz",
+      "integrity": "sha512-UddhVaQ7+V9IfQVVE8AJLNzSmyaaNpZPQsoPQxFNlJyOFxD6RwSTT8L4rb/TwbUctxSFWpyd1J7exzf33Ony/g==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/extension-list": "3.27.3"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.27.3.tgz",
+      "integrity": "sha512-GZPVg4QCFm41yTMPEPeTlH2odNeQwRuWHY/pt3pI5LsfipQ4kDBv6h9we928vJQUnU2Gg9Y3cL5iRbmXIWWTUA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.23.1.tgz",
-      "integrity": "sha512-Zp+qognyNgoaJ9bxkBwIuWJEnQ67RdsHXzv3YOdeGRbkUhd8LT6OL7P0mAuNbMBU8MwHxyJ7C7NsyzwzuVbFzA==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.27.3.tgz",
+      "integrity": "sha512-oHYoE65WfRSM5tCcXi8MtQmzPxz83E2qw0pa2yHBKwr9xCCQUu8vJHJE+EJGduWdaNImv43+6/6kVMeYYbXRKg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/extension-list": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.23.1.tgz",
-      "integrity": "sha512-LLEPizt1ALE7Ek6prlJ1uhoUCT8C/a3PdZpCh3DshM1L3Kv9TENlaJL2GhFl8SVUCwHmWHvXg30+4tIRFBedaQ==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.27.3.tgz",
+      "integrity": "sha512-G5XPCN7lm0nULYPelJC2eUbKbt1q97j67e/HSWxwMYEXhceec5eNAtVfpDCRyXNO9osyBi2kXqLv/IQtxbch9A==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-placeholder": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-2.11.7.tgz",
-      "integrity": "sha512-/06zXV4HIjYoiaUq1fVJo/RcU8pHbzx21evOpeG/foCfNpMI4xLU/vnxdUi6/SQqpZMY0eFutDqod1InkSOqsg==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.23.1.tgz",
-      "integrity": "sha512-hAT9peYkKezRGp/EcPQKtyYQT+2XGUbb26toTr9XIBQIeQCuCpT+FirPrDMrMVWPwcJt7Rv+AzoVjDuBs9wE0A==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.27.3.tgz",
+      "integrity": "sha512-dp6Rs3I4zLVJPvAw2Q9yrNuYKcX5LTONH3/oyULvGsrqq5DKz7pqscfwhwnDSzrgm/3aCz6B9r1BVHlYI/DXlA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-subscript": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-2.11.7.tgz",
-      "integrity": "sha512-I25ZexCddFJ9701DCCtQbX3Vtxzj5d9ss2GAXVweIUCdATCScaebsznyUQoN5papmhTxXsw5OD+K2ZHxP82pew==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.27.3.tgz",
+      "integrity": "sha512-jsnoOWQ40kd7B6NMkdZxsZpcSk/+BevN6TprOVaPbo6cbThjmMCfyL/yCBRTWF/N2KMLMplz1WBhPUEG2Qk3mg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3",
+        "@tiptap/pm": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-superscript": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-2.11.7.tgz",
-      "integrity": "sha512-dNRpCcRJs0Qvv0sZRgbH7Y5hDVbWsGSZjtwFCs/mysPrvHqmXjzo7568kYWTggxEYxnXw6n0FfkCAEHlt0N90Q==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.27.3.tgz",
+      "integrity": "sha512-y37F/ckFXvCkGVx0hk1qYr0XBXUuBstbwcy1AbW7xzPh07cn8xeTa21j3ytSMaAuSaaKh/TGIj/+DhbnovK8cw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3",
+        "@tiptap/pm": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-table": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-2.11.7.tgz",
-      "integrity": "sha512-rfwWkNXz/EZuhc8lylsCWPbx0Xr5FlIhreWFyeoXYrDEO3x4ytYcVOpNmbabJYP2semfM0PvPR5o84zfFkLZyg==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.27.3.tgz",
+      "integrity": "sha512-P7iQ0SkkDWZwnXzQDOVFLXktXlX67VQ3s2YxoJYKTHlc8rPZ4UCaSogFq0G2APyBlizlY3LbMNrDeZAVFOD8wQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-table-cell": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-2.11.7.tgz",
-      "integrity": "sha512-JMOkSYRckc5SJP86yGGiHzCxCR8ecrRENvTWAKib6qer2tutxs5u42W+Z8uTcHC2dRz7Fv54snOkDoqPwkf6cw==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-table-header": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-2.11.7.tgz",
-      "integrity": "sha512-wPRKpliS5QQXgsp//ZjXrHMdLICMkjg2fUrQinOiBa7wDL5C7Y+SehtuK4s2tjeAkyAdj+nepfftyBRIlUSMXg==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-table-row": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-2.11.7.tgz",
-      "integrity": "sha512-K254RiXWGXGjz5Cm835hqfQiwnYXm8aw6oOa3isDh4A1B+1Ev4DB2vEDKMrgaOor3nbTsSYmAx2iEMrZSbpaRg==",
-      "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3",
+        "@tiptap/pm": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.23.1.tgz",
-      "integrity": "sha512-XK0D/eyS1Vm5yUrCtkS0AfgyKLJqpi8nJivCOux/JLhhC4x87R1+mI8NoFDYZJ5ic/afREPSBB8jORqOi0qIHg==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.27.3.tgz",
+      "integrity": "sha512-wSatZ/bop0pleeC18nF90zvWWEoRe/ewZncvm8LjcMrXwq41kTEs3j7nZflMYAh7X8fZvu00UIMeEyCNJl+5Yg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-text-align": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-2.11.7.tgz",
-      "integrity": "sha512-3M8zd9ROADXazVNpgR6Ejs1evSvBveN36qN4GgV71GqrNlTcjqYgQcXFLQrsd2hnE+aXir8/8bLJ+aaJXDninA==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.27.3.tgz",
+      "integrity": "sha512-yyhlwRz0Eh6xQCn+GtTDWUGqxGajT02Qf8zBN/3eZQtl3EZ2xrI8lvfLmcV9SAW0srgMd+5hX0CVV+zKeXuxeg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-text-style": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.23.1.tgz",
-      "integrity": "sha512-fZn1GePlL27pUFfKXKoRZo4L4pZP9dUjNNiS/eltLpbi/SenJ15UKhAoHtN1KQvNGJsWkYN49FjnnltU8qvQ+Q==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.27.3.tgz",
+      "integrity": "sha512-oim4RqFtMBCA4N+J8f8dTFFYZrwyfmXLxLL5SvQkn+kkpfGLv8PqJCnJ4uHxsnHXDNsWHBtVVhfTGUABZsTEHg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.11.7.tgz",
-      "integrity": "sha512-NtoQw6PGijOAtXC6G+0Aq0/Z5wwEjPhNHs8nsjXogfWIgaj/aI4/zfBnA06eI3WT+emMYQTl0fTc4CUPnLVU8g==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.27.3.tgz",
+      "integrity": "sha512-YH7ka/Rp7ZwlzTuQCcs0OZ4CMSx/P/MzbseQKxKebEIZreWaKMZAaED97Fnu0dA66VlreD4/1C7xHJy84ovamg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.27.3"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.3.tgz",
+      "integrity": "sha512-IA2QKUVJgzUPEhhkUfr6P5u5GFVfhiApiEaaHXBz07saL2c4HNoVs2RC18QlZDCtLNKrPR1mUScr72u7uYs+YQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.3",
+        "@tiptap/pm": "3.27.3"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.11.7.tgz",
-      "integrity": "sha512-7gEEfz2Q6bYKXM07vzLUD0vqXFhC5geWRA6LCozTiLdVFDdHWiBrvb2rtkL5T7mfLq03zc1QhH7rI3F6VntOEA==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.3.tgz",
+      "integrity": "sha512-ppiG57RxM3HSHHgcHT0hP6Ib4P56Sd5itxdV4w0hIGHKPGyLLKiAkYp+htIHa9T7IvjMdaqxIlsfyV3ZKsS1sw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "prosemirror-changeset": "^2.2.1",
-        "prosemirror-collab": "^1.3.1",
-        "prosemirror-commands": "^1.6.2",
-        "prosemirror-dropcursor": "^1.8.1",
-        "prosemirror-gapcursor": "^1.3.2",
-        "prosemirror-history": "^1.4.1",
-        "prosemirror-inputrules": "^1.4.0",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.23.0",
-        "prosemirror-schema-basic": "^1.2.3",
-        "prosemirror-schema-list": "^1.4.1",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.37.0"
+        "prosemirror-changeset": "^2.4.1",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-gapcursor": "^1.4.1",
+        "prosemirror-history": "^1.5.0",
+        "prosemirror-inputrules": "^1.5.1",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.9",
+        "prosemirror-schema-list": "^1.5.1",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.5",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.9"
       },
       "funding": {
         "type": "github",
@@ -1263,37 +1035,52 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.11.7.tgz",
-      "integrity": "sha512-K+q51KwNU/l0kqRuV5e1824yOLVftj6kGplGQLvJG56P7Rb2dPbM/JeaDbxQhnHT/KDGamG0s0Po0M3pPY163A==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.27.3.tgz",
+      "integrity": "sha512-xX3baFqiC30skntdhxUUvyJo755ON9c1pE83+2Wiq2g+Qnffg9knUuLCZStHoZZ318yB0aBsKAMvHWLtYDo8AA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tiptap/core": "^2.11.7",
-        "@tiptap/extension-blockquote": "^2.11.7",
-        "@tiptap/extension-bold": "^2.11.7",
-        "@tiptap/extension-bullet-list": "^2.11.7",
-        "@tiptap/extension-code": "^2.11.7",
-        "@tiptap/extension-code-block": "^2.11.7",
-        "@tiptap/extension-document": "^2.11.7",
-        "@tiptap/extension-dropcursor": "^2.11.7",
-        "@tiptap/extension-gapcursor": "^2.11.7",
-        "@tiptap/extension-hard-break": "^2.11.7",
-        "@tiptap/extension-heading": "^2.11.7",
-        "@tiptap/extension-history": "^2.11.7",
-        "@tiptap/extension-horizontal-rule": "^2.11.7",
-        "@tiptap/extension-italic": "^2.11.7",
-        "@tiptap/extension-list-item": "^2.11.7",
-        "@tiptap/extension-ordered-list": "^2.11.7",
-        "@tiptap/extension-paragraph": "^2.11.7",
-        "@tiptap/extension-strike": "^2.11.7",
-        "@tiptap/extension-text": "^2.11.7",
-        "@tiptap/extension-text-style": "^2.11.7",
-        "@tiptap/pm": "^2.11.7"
+        "@tiptap/core": "^3.27.3",
+        "@tiptap/extension-blockquote": "^3.27.3",
+        "@tiptap/extension-bold": "^3.27.3",
+        "@tiptap/extension-bullet-list": "^3.27.3",
+        "@tiptap/extension-code": "^3.27.3",
+        "@tiptap/extension-code-block": "^3.27.3",
+        "@tiptap/extension-document": "^3.27.3",
+        "@tiptap/extension-dropcursor": "^3.27.3",
+        "@tiptap/extension-gapcursor": "^3.27.3",
+        "@tiptap/extension-hard-break": "^3.27.3",
+        "@tiptap/extension-heading": "^3.27.3",
+        "@tiptap/extension-horizontal-rule": "^3.27.3",
+        "@tiptap/extension-italic": "^3.27.3",
+        "@tiptap/extension-link": "^3.27.3",
+        "@tiptap/extension-list": "^3.27.3",
+        "@tiptap/extension-list-item": "^3.27.3",
+        "@tiptap/extension-list-keymap": "^3.27.3",
+        "@tiptap/extension-ordered-list": "^3.27.3",
+        "@tiptap/extension-paragraph": "^3.27.3",
+        "@tiptap/extension-strike": "^3.27.3",
+        "@tiptap/extension-text": "^3.27.3",
+        "@tiptap/extension-underline": "^3.27.3",
+        "@tiptap/extensions": "^3.27.3",
+        "@tiptap/pm": "^3.27.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/diff": {
@@ -1301,13 +1088,8 @@
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
       "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
       "dev": true,
+      "license": "MIT",
       "peer": true
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1316,1076 +1098,1155 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@umbraco-cms/backoffice": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-16.0.0.tgz",
-      "integrity": "sha512-d8YvcCu4Bddps4agKHZoBgmhPhJhffoEEHUFD18iiRx+6ccRighO/qaE/5X8SeZzusSuyFnbeyJRo/5tyu0FRA==",
+      "version": "17.5.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.5.3.tgz",
+      "integrity": "sha512-ZHT3qvOa/kPIROdMGHZmT4cAAIPDOT+CztkX9vGK7Idjv+wz1jEMygMTQnnDe7AUD5EC0Nb9s16YoyVSSg+FsA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=22",
-        "npm": ">=10.9"
+        "node": ">=22.17.1",
+        "npm": ">=10.9.2"
       },
       "peerDependencies": {
-        "@hey-api/client-fetch": "^0.10.0",
-        "@tiptap/core": "2.11.7",
-        "@tiptap/extension-character-count": "2.11.7",
-        "@tiptap/extension-image": "2.11.7",
-        "@tiptap/extension-link": "2.11.7",
-        "@tiptap/extension-placeholder": "2.11.7",
-        "@tiptap/extension-subscript": "2.11.7",
-        "@tiptap/extension-superscript": "2.11.7",
-        "@tiptap/extension-table": "2.11.7",
-        "@tiptap/extension-table-cell": "2.11.7",
-        "@tiptap/extension-table-header": "2.11.7",
-        "@tiptap/extension-table-row": "2.11.7",
-        "@tiptap/extension-text-align": "2.11.7",
-        "@tiptap/extension-underline": "2.11.7",
-        "@tiptap/pm": "2.11.7",
-        "@tiptap/starter-kit": "2.11.7",
+        "@heximal/expressions": ">=0.1.5 <1.0.0",
+        "@hey-api/openapi-ts": ">=0.85.2 <1.0.0",
+        "@microsoft/signalr": "^10.0.0",
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/extension-image": "^3.22.3",
+        "@tiptap/extension-subscript": "^3.22.3",
+        "@tiptap/extension-superscript": "^3.22.3",
+        "@tiptap/extension-table": "^3.22.3",
+        "@tiptap/extension-text-align": "^3.22.3",
+        "@tiptap/extension-text-style": "^3.22.3",
+        "@tiptap/extensions": "^3.22.3",
+        "@tiptap/pm": "^3.22.3",
+        "@tiptap/starter-kit": "^3.22.3",
         "@types/diff": "^7.0.2",
-        "@umbraco-ui/uui": "1.14.0",
-        "@umbraco-ui/uui-css": "1.14.0",
-        "diff": "^7.0.0",
-        "dompurify": "^3.2.5",
+        "@umbraco-ui/uui": "^1.18.1",
+        "@umbraco-ui/uui-css": "^1.18.1",
+        "diff": "^9.0.0",
+        "dompurify": "^3.4.1",
         "element-internals-polyfill": "^3.0.2",
-        "lit": "^3.3.0",
-        "marked": "^15.0.9",
-        "monaco-editor": "^0.52.2",
+        "lit": "^3.3.1",
+        "luxon": "^3.7.2",
+        "marked": "^18.0.0",
+        "monaco-editor": ">=0.55.1 <1.0.0",
         "rxjs": "^7.8.2",
-        "uuid": "^11.1.0"
+        "uuid": "^14.0.0"
       }
     },
     "node_modules/@umbraco-ui/uui": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.14.0.tgz",
-      "integrity": "sha512-et9xGGEcFyIBaMzSbPFt81SDyPdGyV8qyZzLePbs4vDTJiqjtefl0ICZib3Cwm8X4TjCXOcbVMU84wV2RCcIsQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.18.1.tgz",
+      "integrity": "sha512-ICoz0YVy4PXJQx84Spaaak9S4irwAkhqKEMkSAjd2NERmREh0dyD20VL/tKfgE+XUszsXlMyfAHUxiUUmR7WTw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.14.0",
-        "@umbraco-ui/uui-avatar": "1.14.0",
-        "@umbraco-ui/uui-avatar-group": "1.14.0",
-        "@umbraco-ui/uui-badge": "1.14.0",
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-boolean-input": "1.14.0",
-        "@umbraco-ui/uui-box": "1.14.0",
-        "@umbraco-ui/uui-breadcrumbs": "1.14.0",
-        "@umbraco-ui/uui-button": "1.14.0",
-        "@umbraco-ui/uui-button-copy-text": "1.14.0",
-        "@umbraco-ui/uui-button-group": "1.14.0",
-        "@umbraco-ui/uui-button-inline-create": "1.14.0",
-        "@umbraco-ui/uui-card": "1.14.0",
-        "@umbraco-ui/uui-card-block-type": "1.14.0",
-        "@umbraco-ui/uui-card-content-node": "1.14.0",
-        "@umbraco-ui/uui-card-media": "1.14.0",
-        "@umbraco-ui/uui-card-user": "1.14.0",
-        "@umbraco-ui/uui-caret": "1.14.0",
-        "@umbraco-ui/uui-checkbox": "1.14.0",
-        "@umbraco-ui/uui-color-area": "1.14.0",
-        "@umbraco-ui/uui-color-picker": "1.14.0",
-        "@umbraco-ui/uui-color-slider": "1.14.0",
-        "@umbraco-ui/uui-color-swatch": "1.14.0",
-        "@umbraco-ui/uui-color-swatches": "1.14.0",
-        "@umbraco-ui/uui-combobox": "1.14.0",
-        "@umbraco-ui/uui-combobox-list": "1.14.0",
-        "@umbraco-ui/uui-css": "1.14.0",
-        "@umbraco-ui/uui-dialog": "1.14.0",
-        "@umbraco-ui/uui-dialog-layout": "1.14.0",
-        "@umbraco-ui/uui-file-dropzone": "1.14.0",
-        "@umbraco-ui/uui-file-preview": "1.14.0",
-        "@umbraco-ui/uui-form": "1.14.0",
-        "@umbraco-ui/uui-form-layout-item": "1.14.0",
-        "@umbraco-ui/uui-form-validation-message": "1.14.0",
-        "@umbraco-ui/uui-icon": "1.14.0",
-        "@umbraco-ui/uui-icon-registry": "1.14.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.14.0",
-        "@umbraco-ui/uui-input": "1.14.0",
-        "@umbraco-ui/uui-input-file": "1.14.0",
-        "@umbraco-ui/uui-input-lock": "1.14.0",
-        "@umbraco-ui/uui-input-password": "1.14.0",
-        "@umbraco-ui/uui-keyboard-shortcut": "1.14.0",
-        "@umbraco-ui/uui-label": "1.14.0",
-        "@umbraco-ui/uui-loader": "1.14.0",
-        "@umbraco-ui/uui-loader-bar": "1.14.0",
-        "@umbraco-ui/uui-loader-circle": "1.14.0",
-        "@umbraco-ui/uui-menu-item": "1.14.0",
-        "@umbraco-ui/uui-modal": "1.14.0",
-        "@umbraco-ui/uui-pagination": "1.14.0",
-        "@umbraco-ui/uui-popover": "1.14.0",
-        "@umbraco-ui/uui-popover-container": "1.14.0",
-        "@umbraco-ui/uui-progress-bar": "1.14.0",
-        "@umbraco-ui/uui-radio": "1.14.0",
-        "@umbraco-ui/uui-range-slider": "1.14.0",
-        "@umbraco-ui/uui-ref": "1.14.0",
-        "@umbraco-ui/uui-ref-list": "1.14.0",
-        "@umbraco-ui/uui-ref-node": "1.14.0",
-        "@umbraco-ui/uui-ref-node-data-type": "1.14.0",
-        "@umbraco-ui/uui-ref-node-document-type": "1.14.0",
-        "@umbraco-ui/uui-ref-node-form": "1.14.0",
-        "@umbraco-ui/uui-ref-node-member": "1.14.0",
-        "@umbraco-ui/uui-ref-node-package": "1.14.0",
-        "@umbraco-ui/uui-ref-node-user": "1.14.0",
-        "@umbraco-ui/uui-scroll-container": "1.14.0",
-        "@umbraco-ui/uui-select": "1.14.0",
-        "@umbraco-ui/uui-slider": "1.14.0",
-        "@umbraco-ui/uui-symbol-expand": "1.14.0",
-        "@umbraco-ui/uui-symbol-file": "1.14.0",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.14.0",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.14.0",
-        "@umbraco-ui/uui-symbol-folder": "1.14.0",
-        "@umbraco-ui/uui-symbol-lock": "1.14.0",
-        "@umbraco-ui/uui-symbol-more": "1.14.0",
-        "@umbraco-ui/uui-symbol-sort": "1.14.0",
-        "@umbraco-ui/uui-table": "1.14.0",
-        "@umbraco-ui/uui-tabs": "1.14.0",
-        "@umbraco-ui/uui-tag": "1.14.0",
-        "@umbraco-ui/uui-textarea": "1.14.0",
-        "@umbraco-ui/uui-toast-notification": "1.14.0",
-        "@umbraco-ui/uui-toast-notification-container": "1.14.0",
-        "@umbraco-ui/uui-toast-notification-layout": "1.14.0",
-        "@umbraco-ui/uui-toggle": "1.14.0",
-        "@umbraco-ui/uui-visually-hidden": "1.14.0"
+        "@umbraco-ui/uui-action-bar": "1.18.1",
+        "@umbraco-ui/uui-avatar": "1.18.1",
+        "@umbraco-ui/uui-avatar-group": "1.18.1",
+        "@umbraco-ui/uui-badge": "1.18.1",
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-boolean-input": "1.18.1",
+        "@umbraco-ui/uui-box": "1.18.1",
+        "@umbraco-ui/uui-breadcrumbs": "1.18.1",
+        "@umbraco-ui/uui-button": "1.18.1",
+        "@umbraco-ui/uui-button-copy-text": "1.18.1",
+        "@umbraco-ui/uui-button-group": "1.18.1",
+        "@umbraco-ui/uui-button-inline-create": "1.18.1",
+        "@umbraco-ui/uui-card": "1.18.1",
+        "@umbraco-ui/uui-card-block-type": "1.18.1",
+        "@umbraco-ui/uui-card-content-node": "1.18.1",
+        "@umbraco-ui/uui-card-media": "1.18.1",
+        "@umbraco-ui/uui-card-user": "1.18.1",
+        "@umbraco-ui/uui-caret": "1.18.1",
+        "@umbraco-ui/uui-checkbox": "1.18.1",
+        "@umbraco-ui/uui-color-area": "1.18.1",
+        "@umbraco-ui/uui-color-picker": "1.18.1",
+        "@umbraco-ui/uui-color-slider": "1.18.1",
+        "@umbraco-ui/uui-color-swatch": "1.18.1",
+        "@umbraco-ui/uui-color-swatches": "1.18.1",
+        "@umbraco-ui/uui-combobox": "1.18.1",
+        "@umbraco-ui/uui-combobox-list": "1.18.1",
+        "@umbraco-ui/uui-css": "1.18.1",
+        "@umbraco-ui/uui-dialog": "1.18.1",
+        "@umbraco-ui/uui-dialog-layout": "1.18.1",
+        "@umbraco-ui/uui-file-dropzone": "1.18.1",
+        "@umbraco-ui/uui-file-preview": "1.18.1",
+        "@umbraco-ui/uui-form": "1.18.1",
+        "@umbraco-ui/uui-form-layout-item": "1.18.1",
+        "@umbraco-ui/uui-form-validation-message": "1.18.1",
+        "@umbraco-ui/uui-icon": "1.18.1",
+        "@umbraco-ui/uui-icon-registry": "1.18.1",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.1",
+        "@umbraco-ui/uui-input": "1.18.1",
+        "@umbraco-ui/uui-input-file": "1.18.1",
+        "@umbraco-ui/uui-input-lock": "1.18.1",
+        "@umbraco-ui/uui-input-password": "1.18.1",
+        "@umbraco-ui/uui-keyboard-shortcut": "1.18.1",
+        "@umbraco-ui/uui-label": "1.18.1",
+        "@umbraco-ui/uui-loader": "1.18.1",
+        "@umbraco-ui/uui-loader-bar": "1.18.1",
+        "@umbraco-ui/uui-loader-circle": "1.18.1",
+        "@umbraco-ui/uui-menu-item": "1.18.1",
+        "@umbraco-ui/uui-modal": "1.18.1",
+        "@umbraco-ui/uui-pagination": "1.18.1",
+        "@umbraco-ui/uui-popover": "1.18.1",
+        "@umbraco-ui/uui-popover-container": "1.18.1",
+        "@umbraco-ui/uui-progress-bar": "1.18.1",
+        "@umbraco-ui/uui-radio": "1.18.1",
+        "@umbraco-ui/uui-range-slider": "1.18.1",
+        "@umbraco-ui/uui-ref": "1.18.1",
+        "@umbraco-ui/uui-ref-list": "1.18.1",
+        "@umbraco-ui/uui-ref-node": "1.18.1",
+        "@umbraco-ui/uui-ref-node-data-type": "1.18.1",
+        "@umbraco-ui/uui-ref-node-document-type": "1.18.1",
+        "@umbraco-ui/uui-ref-node-form": "1.18.1",
+        "@umbraco-ui/uui-ref-node-member": "1.18.1",
+        "@umbraco-ui/uui-ref-node-package": "1.18.1",
+        "@umbraco-ui/uui-ref-node-user": "1.18.1",
+        "@umbraco-ui/uui-scroll-container": "1.18.1",
+        "@umbraco-ui/uui-select": "1.18.1",
+        "@umbraco-ui/uui-slider": "1.18.1",
+        "@umbraco-ui/uui-symbol-expand": "1.18.1",
+        "@umbraco-ui/uui-symbol-file": "1.18.1",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.18.1",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.18.1",
+        "@umbraco-ui/uui-symbol-folder": "1.18.1",
+        "@umbraco-ui/uui-symbol-lock": "1.18.1",
+        "@umbraco-ui/uui-symbol-more": "1.18.1",
+        "@umbraco-ui/uui-symbol-sort": "1.18.1",
+        "@umbraco-ui/uui-table": "1.18.1",
+        "@umbraco-ui/uui-tabs": "1.18.1",
+        "@umbraco-ui/uui-tag": "1.18.1",
+        "@umbraco-ui/uui-textarea": "1.18.1",
+        "@umbraco-ui/uui-toast-notification": "1.18.1",
+        "@umbraco-ui/uui-toast-notification-container": "1.18.1",
+        "@umbraco-ui/uui-toast-notification-layout": "1.18.1",
+        "@umbraco-ui/uui-toggle": "1.18.1",
+        "@umbraco-ui/uui-visually-hidden": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-action-bar": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.14.0.tgz",
-      "integrity": "sha512-cTX0TvVxNC7EFMtEqMGMBFC8E5O8bedmJ1Hkddvp4lAzrbLGrFTPcwOG/kISaSXzFrnMzyQNdi3s23orcL5VRA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.18.1.tgz",
+      "integrity": "sha512-SkCMPFazNJJU/LLEfOO5R5UCyLPSpOJPq+nPlDOCZN/drt8hPscWz2G5VXdwVua3LmfAGaiBZQMjSC2khJKqwQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-button-group": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-button-group": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-avatar": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.14.0.tgz",
-      "integrity": "sha512-ykYlbHV4K+zW7viv+oqfsGcL0ZII4vQy3YnPusFiz6bS3ceDDpY9MpRtuDTv4z+PXW4Wo1FjB2iMHrza55/RUw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.18.1.tgz",
+      "integrity": "sha512-Sve2zv5tk7tjUBg+Zthw5R4P/95RtWsokoybm8cnyxUI1zPkrxCCBxcDXh2QwA1SCxk1B5o6WZEmFxUqjIlL1Q==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-avatar-group": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.14.0.tgz",
-      "integrity": "sha512-8pLxQvtW1yuaReuSy0wq6kYZXPSiZjKv8ecmciLgWr9aKGR++CwYrwWKA3c+jZTarb8dz4MGMnQpqHCTqlQbpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.18.1.tgz",
+      "integrity": "sha512-TL5SzOha6KNoPaYaDC5s0ZpnUtj5q09/T/dJd7CO5bKsDzJQHGHtNKO1w8lzWJkPqASZr4QU0P6LwugiIZocvA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.14.0",
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-avatar": "1.18.1",
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-badge": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.14.0.tgz",
-      "integrity": "sha512-iUosWuf7XngJBdwmvx8BZkzsollH4146Gt2CQBGltFZRCZ7uUkB2zCYb2E1ys4BEWuKHK4ZLiOcYtpPtoNeZJQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.18.1.tgz",
+      "integrity": "sha512-WgWY4md/+wcmKfjPpkn2M3bHBxZDp6h80D6N1f81SjqP4AuK3dA77cB8gDIBNeOdULMy/Mh8dqmjwoTiiEEPAQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-base": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.14.0.tgz",
-      "integrity": "sha512-m/BQYeKL9XmHPfHfCfSwTjcmUmJxynI0m4yqLTmQqQ3x1hiRqqfYyLSrpi3uW1H/HCxttUkxEwkhAdYogMDIpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.18.1.tgz",
+      "integrity": "sha512-cI5EPVIgN8H8NaVrc+LLGL09pEAa1LoYgf+BCC1IV4IsmPjTRigSrNLpSy09Yr2n4+oZcu3YIRcsvjAGQwDSJQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "lit": ">=2.8.0"
       }
     },
     "node_modules/@umbraco-ui/uui-boolean-input": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.14.0.tgz",
-      "integrity": "sha512-O+/GzpF2mNLdhXXNAfxI0k5VaR7CUnUxDDxYPhMgmuLOBwdjiq9iScJM4MUl+l7hihF5ue7os6I8DY2CnG7LJQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.18.1.tgz",
+      "integrity": "sha512-6semFRqyEFqqJkO51BfEB1aARbbhBRHBpwBPsirJ4AWeoy9W0iH39DGn7h/P+TGUgTeRREelWR/Y1B75lvy6AQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-box": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.14.0.tgz",
-      "integrity": "sha512-VjD6MtEnJuHOYarFtLvn/Dyz2MRJ0sPXSDTZ3HWsF0G5fdAUB487ErOGb8CL1JtmUYgZOy6N3CqPlFyWHD+DIA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.18.1.tgz",
+      "integrity": "sha512-7fKQbY2zbsDwWJ77M17iOSMnKh8pKfss9XJeQM1S+G9EB3vWaoIosBBm6ZKNBsuOnsL8abMuKy6mAl1yR5GdaA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-css": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-css": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-breadcrumbs": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.14.0.tgz",
-      "integrity": "sha512-IxHPUnIaGyvo54oDdcJf4AfzkYF1Nf727SCLHD28WqMh4QCKQQsyBGa5xhFjcQ4RSediNwvAnY7dNVVYu9OrzQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.18.1.tgz",
+      "integrity": "sha512-qTIMaDTTbr6WsC7v/JXtxKoQT9lW3lxP7VL7WxiE4YPIEK3YfEgfHcDtyDHntdT62wOUNMRh3FAzonnm9AAhkA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-responsive-container": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-button": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.14.0.tgz",
-      "integrity": "sha512-TVCPLVcXR4wGjtLtrTYOjoAdvwQPiCep1GiHAbozD0QKNgOqjZ2fE3CapwEwoaSNGcgw/37t0KMhUqfmZgYo2g==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.18.1.tgz",
+      "integrity": "sha512-iBgX3W6x8wnn8rLilFGNjh7xDMq4zdGWSNAeuUAV2Xh/pZXj3djC/kwWIfIwuRqHhUd91tMzF592qCDGBv5vnQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-button-copy-text": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.14.0.tgz",
-      "integrity": "sha512-cE3ZjSaWzzdgYdNtGv1SzIClMoCxqL86+QPz9zMYvN//yA8YQmkv7y2eUyT+lKFNJXXHMgzVKMhoSn8aUzvQrA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.18.1.tgz",
+      "integrity": "sha512-JvphmA/EEG3UmGtejMV5Rg5stl4SOQ0avC17EwVLTydFXoyWh5e1puP89LFBwbxazYg0/AHBEKET0YvgDPTcow==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-button": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-button": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-button-group": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.14.0.tgz",
-      "integrity": "sha512-W4Jf671PqtnBnYKWNyyB6rgq88qyT0IWhqUR3ilJS45znIiht/ec5xDhTFoyhLWP9+zQn/3e8EqZbmnJUj2HAA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.18.1.tgz",
+      "integrity": "sha512-F/H2gsg9J03AK09X8Lbl2kaFQIP9AJr9+bZHAmBKRUwsyS81JiK+YYqqBa2hj4GDZb0UgWDt7iQfe5MIPRVAnQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-button-inline-create": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.14.0.tgz",
-      "integrity": "sha512-vDOZJEfjQDqIKymdpxD3h/uvBacXu/yD/xnHMrxADeMQYinvNn0AFjTFBakgfusymRLjXQubrJ63MWqidTRsQQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.18.1.tgz",
+      "integrity": "sha512-FWcQbwAe/MmvmcQTkVHjapgOjT2UesI9nMasZ8HO6t75hSejyAuenGTdb2491DcMHyWdoQXrlRUnXkPRwE70Wg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-card": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.14.0.tgz",
-      "integrity": "sha512-9A44pCbx9nyBtbvFE26FiP+rLE2rUg177vgoMTuURuszYoiEgfU8ixVhWCbDD14LpxET0/Yg9RNiMYF8K1bDvw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.18.1.tgz",
+      "integrity": "sha512-516TklIpLXAcKb92EgUnLMTcr0ywD4Xha69Q9ttRm0AOESceAxf9FAyP/cGG1ZXtMV5QJKhcYIo1usNMSe9etQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-checkbox": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-card-block-type": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.14.0.tgz",
-      "integrity": "sha512-FQAInMb4AKj11Jy3TQTc6iz80h0ulmlraw3CtFbnOpwHIRP/aqUVGCW0Zb+Yykz1DGmmGvFE1u1epK/jH//6aQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.18.1.tgz",
+      "integrity": "sha512-UX9okjxMJGmHGXgKIiHIOOiyKA6ELrDm18Ru4ogxOycq3OxRC1qnzO2SgVpxRmmiIvQNpQ6Y/HxdHY/HCl08DQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-card": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-card": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-card-content-node": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.14.0.tgz",
-      "integrity": "sha512-KcXiUfG0ulgvXWuqOGu3LTcRVoGru+Q4sj4q0bV9H/d3ZfY1idPqhkbM7v6TO56gzCng0DJ/kTL0/H5IWd8IcA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.18.1.tgz",
+      "integrity": "sha512-tS6tnQs7i9UYf+ssP96nsgTKgTaLWk58ioQv7OlltVWHPs6kCcO1FmJLi9fqSQMT1k+/xlxw1FQOr1IUNL8lUA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-card": "1.14.0",
-        "@umbraco-ui/uui-icon": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-card": "1.18.1",
+        "@umbraco-ui/uui-icon": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-card-media": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.14.0.tgz",
-      "integrity": "sha512-Lnr8Y1bxj6QoleSMCj8GDsyJu1N5Rm105/nHYdnPO3+JcNNv3ThodKdHXYo/slSLrcVOoPJHNAQodZG66mIqsg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.18.1.tgz",
+      "integrity": "sha512-pv6fXxmNTs1Lju15SkxMACMS2hM3wxrprIl5k3wGzFJDPcrWhEJxtgIvxEcugjHhs1eyWVg8khxb8Abuvaxdqw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-card": "1.14.0",
-        "@umbraco-ui/uui-symbol-file": "1.14.0",
-        "@umbraco-ui/uui-symbol-folder": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-card": "1.18.1",
+        "@umbraco-ui/uui-symbol-file": "1.18.1",
+        "@umbraco-ui/uui-symbol-folder": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-card-user": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.14.0.tgz",
-      "integrity": "sha512-ZBFWO2109+A9SkkznqNHUiul6G6zab/D318yz0wMTW6m2R0E8QE9mljIw8Entd720HeZlvOKpvK3ElSTNlxnJg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.18.1.tgz",
+      "integrity": "sha512-KLRBNYP0oqVIu/6+haSpzLDfkTgwJ9epMHHKn1pF41aa5jkhpv8ZqA42KqpekNObNWc+TS/JNPmGaHoEozahaQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.14.0",
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-card": "1.14.0"
+        "@umbraco-ui/uui-avatar": "1.18.1",
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-card": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-caret": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.14.0.tgz",
-      "integrity": "sha512-c+71esCgWn7V6Z8gr9fZkfw9BQgewZi5pbJ8R1G6HLEzz0NN11zAn5BAVebdxF5OUi/ajFqvxnAYOSSiWel5tg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.18.1.tgz",
+      "integrity": "sha512-KIEPWr1iTOoAFc81evElyJ+o+iY7sH6gYWtyls4foVNOHqfCUUZeoq7XwTb2NvAtjvnAQh6a4jt6J2mupGs+sg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-checkbox": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.14.0.tgz",
-      "integrity": "sha512-qD/O8H7pcPnJkaf5iWjDKg89LgQKZeuBiRmrXqVePDk0HHjdZ+8TJlDaANRyBq5JePezrj6UpHPVabYDqXIJYQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.18.1.tgz",
+      "integrity": "sha512-vtq/z4hmCYQY8EMCNI5dodMNdv2aTNbXx6uNUZzOD850ctR4eFn4IJXZeQEC0fuBMQgJ7mEtC1LGIH4rnNjMKQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-boolean-input": "1.14.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-boolean-input": "1.18.1",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-color-area": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.14.0.tgz",
-      "integrity": "sha512-ijja8REx/1OhG2ZA1yK98Q8IhSeDf+GIjfCvkR1ptzzFkz1Wiv1mvxkh9eExByidp90SgsTF3kdUxR8x6V570A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.18.1.tgz",
+      "integrity": "sha512-ECV+9gKH8q9xNp/7ln+0IL5zIJJkE1vunXrOw78yy41tRIB2F/rmh/ucz9jqxOj/kMrk02YZDilymzBwLAIt5w==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
+        "@umbraco-ui/uui-base": "1.18.1",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-picker": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.14.0.tgz",
-      "integrity": "sha512-WG7I2mYDjW3W27V3LDRpUrZfkjnnuHPo8+X4ZBnY6xRXnQ83hxbdqXkaKYI6VY1dMhhqGa82wrbb4NBHGkKBiQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.18.1.tgz",
+      "integrity": "sha512-kt0o1UZxtjrNrhlhCwjsKF44Wcx3bIT+lSUhCr30FuDvp/JpRlNc9/bsQvdaVlVp+heD6KCJvNMzzrgBEVSqKQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-popover-container": "1.14.0",
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-popover-container": "1.18.1",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-slider": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.14.0.tgz",
-      "integrity": "sha512-8eNA+7GJNVl68amAJIbCWMe/8usWanZ1fKXPf3ZJ54K65K2cDYd2hS7DEVEwSXo+AV9iMeBYgbHIRBqVPZ89jw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.18.1.tgz",
+      "integrity": "sha512-i2n0ua+X06LBseW5evRytvJ4Unh9Bue/JLbtLPW2F/kywzAk7yIilr0vRgbzEdrFWBBuCp4E95tVfxCnBCX4NA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-color-swatch": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.14.0.tgz",
-      "integrity": "sha512-1c2bNmEqL5J1ZW24adzSsGDwnYFQOyjsI29M+UQdlTZW16s3zh9O97414KIN9ivE+SkgbE7c9lZhNEKyi2IJpw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.18.1.tgz",
+      "integrity": "sha512-q2+Q2B8zf/1ukpu0Y7liO2jMVcjRznoaYhjH211sGJoI2SJK/uuXfXmH3Mh0vt5pvPBQL2DYc2kUv3oQMQnG2w==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.14.0",
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.1",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-swatches": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.14.0.tgz",
-      "integrity": "sha512-UIQysF89CZH0CKwhzbd+1BZAXxUlnCmHoWDGot+Mb4sGZL5esrEB0QQmhJOVO/ehMP+GoFUnh4fWLXUCzRPdvw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.18.1.tgz",
+      "integrity": "sha512-sA1B54zI4rLPJpCL0U4fUeb3Yd3zFBZGobBOTxUkh3p0t5qtyjghoJ23FPR3ebOW9mbGaaN67CU6FMddLmybqg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-color-swatch": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-color-swatch": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-combobox": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.14.0.tgz",
-      "integrity": "sha512-ZKa0KF0ADSX//hm116QdEDjQgyZK1ahY+hzOtdU7EDlJBQdTq3cHtwn6B8JdhPoVlS0Yd3XB+oQ7UXjYn7rGQQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.18.1.tgz",
+      "integrity": "sha512-eR8ClnVoLgAkWA1L1GLe80g0q1ZsmZi/8B9vVy7oBZNJxs5FcnjUnaJwOlL5EZIQssiZMovHBkBnDZA6IVkM+g==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-button": "1.14.0",
-        "@umbraco-ui/uui-combobox-list": "1.14.0",
-        "@umbraco-ui/uui-icon": "1.14.0",
-        "@umbraco-ui/uui-popover-container": "1.14.0",
-        "@umbraco-ui/uui-scroll-container": "1.14.0",
-        "@umbraco-ui/uui-symbol-expand": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-button": "1.18.1",
+        "@umbraco-ui/uui-combobox-list": "1.18.1",
+        "@umbraco-ui/uui-icon": "1.18.1",
+        "@umbraco-ui/uui-popover-container": "1.18.1",
+        "@umbraco-ui/uui-scroll-container": "1.18.1",
+        "@umbraco-ui/uui-symbol-expand": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-combobox-list": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.14.0.tgz",
-      "integrity": "sha512-CRsRycwyb9CeyNINQ1KztGAHTRhQcphVEl/bLVr3jTtuqSWWxKsGQVDe69iKNAfHuiU3o7MlsUH0+ea296x/8w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.18.1.tgz",
+      "integrity": "sha512-eL1nOjojERfZPd/OvaHVC6Wiv5UHm1xrq0w2j9kAHoN2LgkrgbENsv/MXcAJa66QTvPsSWeBF2APb/Yoo2ipMA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-css": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.14.0.tgz",
-      "integrity": "sha512-M0zmrjBpDzrb3r+l1qMNGEhJbJSHNeR7PDtpHoMaO96ozaZSL/87XzpwsBklwTR9xyfm+VgDFNTqQXqYnS2e/A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.18.1.tgz",
+      "integrity": "sha512-NbC1YlJDZhfu3IFXaJhD6O1eZpR0iBBeHruqBF9njS2TsSCtjInrkB4xSskGuhR6D81oWbg+8tqGD5mdurSujw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "lit": ">=2.8.0"
       }
     },
     "node_modules/@umbraco-ui/uui-dialog": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.14.0.tgz",
-      "integrity": "sha512-eZdmNLkSW5OAETTZlvUKByQbXv/4/tYznNHCHyWxxGrYuHVHh5sNj+3ZUbZp+VjIy1zd42slKh/KDmYV6pBarQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.18.1.tgz",
+      "integrity": "sha512-NTzvGeeiutDYnvRxObr3SppF7FZhFL9Rq+aerHX2nzIf82/Qj8qsgeYqmzg+sccm0CbhpmPe1rPgCE9CffhsWA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-css": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-css": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-dialog-layout": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.14.0.tgz",
-      "integrity": "sha512-rYlwHk5zsX+eBZLBxI/68W6Q1vb7G/NuZoasquQXZ7jgxRhaRw199YQojtUCWtIowWn2uqqbD2a0RYPs9n3FIg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.18.1.tgz",
+      "integrity": "sha512-v8kNIDXe+5lIsYtXWOdD8vB4RYkuP0a3zxLQ30aSLAgpP+Btc/U4bjuX8yx7U8OeWbgyKU2bPE1nesTJ2nSv+g==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-file-dropzone": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.14.0.tgz",
-      "integrity": "sha512-GSy0mlR5KsyC9oF3CMB2qwuGiT5P3moVFxanRAO7u8qimRAO2jLS0/8u1QCh120AGRQZzDhw/TJ9XF7NXTWJtA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.18.1.tgz",
+      "integrity": "sha512-YE+Os7h0+a7He5Xy90oCErWP4Ib836cdDmSlPKVq/8sW7HrTg7JiONn6siRCSQ/Da4CBDKqYlQ3nuMsbzTVqZA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-file-preview": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.14.0.tgz",
-      "integrity": "sha512-UGxlpKoCVjFYbkNfXcMi0kCSjcocnHlTHH1fyk/Mg5jZ1OZCmV8dnQQKCB139X9FdHZhL0QeZA3KZUYA28iqaQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.18.1.tgz",
+      "integrity": "sha512-aaLKfLp3iuvOBdY3qhX1R9qCc31HA8EHeLz81DcmY/En7xiYzcuhE653jY0fTKCDAbwfl6BMVAyxhqZPKYdUDg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-symbol-file": "1.14.0",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.14.0",
-        "@umbraco-ui/uui-symbol-folder": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-symbol-file": "1.18.1",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.18.1",
+        "@umbraco-ui/uui-symbol-folder": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-form": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.14.0.tgz",
-      "integrity": "sha512-UoEP62nCNTa4ILDNFX2ASNN95XfUugPhGmtUdKmvTUH6F3NSai2iiLIp/dM+GBC4PJXmt8rzq6NdLqYonkMK+w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.18.1.tgz",
+      "integrity": "sha512-yfXqOyDIVWJ65XmOBhuT+JCzLOezEOlDi/jfn5NapwuEz+iZ+WTlHd6/7pQDI2p7MtZu+cIxiKSD1sg25EFvmQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-form-layout-item": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.14.0.tgz",
-      "integrity": "sha512-1ahnmF9Ciw0RC/pRAS3FJ2vVmnpQ6O20bwqJrCTYvJQeqJXV3bzSxYmMY/s6Z5tsoNDzkfYcTHfnti/MmyuFJw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.18.1.tgz",
+      "integrity": "sha512-Wj6dLV4XpTEuXpGMJaeki0XIMyDzhoVm2xqprJwvh+ErK0jHgZn3sz65U+NeB4i0W29kB23Cv1EeEQNsfjWh/A==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-form-validation-message": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-form-validation-message": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-form-validation-message": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.14.0.tgz",
-      "integrity": "sha512-rv+mId8htw/8V3rle5bOjgWK8X+3IX7B+PAvFAfy+lc89OUV+OT04RGy0sg3hhncoPsIT8EhQ2MYunIyh3MwnA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.18.1.tgz",
+      "integrity": "sha512-aWFxgSuY0JNyHfYJgZX4Vnqc/GKidm0/jH3wsHQq8l2FgPcalT9CK9nrnC/5SzsTRptWmLavPlPj8Oqy2teRwQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-icon": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.14.0.tgz",
-      "integrity": "sha512-IdBRPC8xc9leIBRaHmTVoGhxRkz8CNeYjgJLNBauFox5uSkWuE7OE9BUYBJKdZz4k8yHLHHrWHVkcaHvgF+QUw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.18.1.tgz",
+      "integrity": "sha512-VcTX83sGDVNpcELF+1Y9HLc3HRI+LxMwIUQA5FF8Rro2mW/2CL16KCszcsG78Pn5UexuDW6Gzm8liJoDCQrIrw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-icon-registry": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.14.0.tgz",
-      "integrity": "sha512-N9cXDF6B3R+h2TCaCHkOJUTSsD10Wei8NrldvYL2fhBqG8FgaquqBI/715NGoRtwp9KKz74N/Z6EIn2MBiMaMQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.18.1.tgz",
+      "integrity": "sha512-IDA2NhgnZx70BUY3cmhp+gcmKHC1FRr2A6qElolLvhkIVo2mlaeaUlCWkEBWfBs1jVs2lKpZZ56vUHZZLgS9eg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-icon": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-icon": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-icon-registry-essential": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.14.0.tgz",
-      "integrity": "sha512-NjkNmQpMHLcyGakqGlASyPOr8Vnr8+KCdExfkbDdg07iDFlzyGyNmCkTdzY2tNXsIq5bD1c4nzHYmE76FszorQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.18.1.tgz",
+      "integrity": "sha512-0lFs8DyMTx40DlgaA9+Nf8FH/z6h+y+HqiiQpeqgdUY4DrSl/Vv9c7YQBd6OVerVj8dYGD9MFV72gt/WZA8+bw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-icon-registry": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-icon-registry": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-input": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.14.0.tgz",
-      "integrity": "sha512-FeYiTUzCcZdNtury6B8ZMl66mW/fGfgXMB5HvIVDFp0ik+WpC8vLcQqHgJ/qFxWGF32H0qIsVqLnzcwkAwvRxw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.18.1.tgz",
+      "integrity": "sha512-44gUAIx8mxdeoeWTeCo4dCxihOmSwk36PWB7SbOlJMZZ0pk17GJ8D7A3u6GSx4aruv4+avtymgzH/WRXLR/bZQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-input-file": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.14.0.tgz",
-      "integrity": "sha512-l4RcQWf+0OLM9i9NWvnMkQtzzNcALBRmtiTBLdz6ROFm2Z+S3MuT8vzl0QiduJNWK5gzANu/FFuTL70fIh/BDw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.18.1.tgz",
+      "integrity": "sha512-nIKxk+d7NgOU33OOOxpw9T4nSmiqiOTYi6OxU1T5XUxIHzkCzIjvvdouvBW1eyI+kqlWx/2tExoFvl/LZ0eu3A==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.14.0",
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-button": "1.14.0",
-        "@umbraco-ui/uui-file-dropzone": "1.14.0",
-        "@umbraco-ui/uui-icon": "1.14.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.14.0"
+        "@umbraco-ui/uui-action-bar": "1.18.1",
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-button": "1.18.1",
+        "@umbraco-ui/uui-file-dropzone": "1.18.1",
+        "@umbraco-ui/uui-icon": "1.18.1",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-input-lock": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.14.0.tgz",
-      "integrity": "sha512-wt/VL43EpHJcvf9GEnXSuHG/iW7yI7vD3wEWI+wgCKv9SdTzE/M4aPon/pxnQsVCvGvWhWvdFeGdlfwhXSurLQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.18.1.tgz",
+      "integrity": "sha512-zD2f57KAkX0XczIyMamS2FjF3yO0iWjTQy8fhuCCmN4+4oXuTn9t/YQSsLj4Jx7+2FPtv+kC/RFzaIUn9p93bA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-button": "1.14.0",
-        "@umbraco-ui/uui-icon": "1.14.0",
-        "@umbraco-ui/uui-input": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-button": "1.18.1",
+        "@umbraco-ui/uui-icon": "1.18.1",
+        "@umbraco-ui/uui-input": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-input-password": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.14.0.tgz",
-      "integrity": "sha512-XCc/0QJH2w9PZJPouhbJbMR+w0QKUusut1MWW9NsfzRheHkcDuzc3Vf69OLFGGww/FjYjkxwT9as/2aLXxotjw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.18.1.tgz",
+      "integrity": "sha512-EY8nECvV7LY7/uxk8thNSZeR5fHGchSceOJzSQ7NNbiystA8PcnyCtWFhHnhRN48ldomY+yDcyuTdw/h8++pKQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.14.0",
-        "@umbraco-ui/uui-input": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.1",
+        "@umbraco-ui/uui-input": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-keyboard-shortcut": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.14.0.tgz",
-      "integrity": "sha512-G3LCdfP5uPe00bg8kKBMZhLan8gH7QbSRMX7aMsT+Fc6nAyWWTwJ/Qt4qJjk/fbeHts1OWD+sbHdRtXK+DotRA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.18.1.tgz",
+      "integrity": "sha512-HBFIorcc/iaXuk4a+tlAIcSQB1E9Np8sFhqyiJQCP81/Rgb2y1hlbtigmxQmMe+4vToFPjqXWovzrllwSfW1PQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-label": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.14.0.tgz",
-      "integrity": "sha512-a22p01O0CqnNTxQxmjPwCFBFXi5KKzhpno4DXjSDVTmeJc85IxiR5ODAELKHJf6XwZMkOv+QG+AZuIJFVEZ13Q==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.18.1.tgz",
+      "integrity": "sha512-x6MWTY9F/rb8A9BkKiVvXAH9bMbNN7G+XNLrYWLjuFNNoPf8oWkr+6MviOlRp+7Wj2UnXaJCtkOnRfjvGnPyLg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-loader": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.14.0.tgz",
-      "integrity": "sha512-2/HNDk0AZQ992hHYQk+VP5GetofSKxCsLf77/wiswyz48kM9eJ9wkieovxzLK1IuOQs0A+cCe2NnU/z5fZnvvw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.18.1.tgz",
+      "integrity": "sha512-cmqZY8uzqtCf8/Jf8+ti8s1tsTfvYQtpJf+fSRZbrVw4kIAjiOVRAId+rmDJzJvFPQoQP0ksDWGR5HhLJT9G4A==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-loader-bar": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.14.0.tgz",
-      "integrity": "sha512-hAviuSx29RPWpYIqmWiGmW31r3nj8A1VGobmdVwR0BJHfdxee57ZrNGsEZhK6pzuHSvshGTITNwLk03E1UA/Nw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.18.1.tgz",
+      "integrity": "sha512-TskxN/F6DMYrsez3fpWnD1VrNsunJAaccA1zaFTb4phXfcIXhv5+yq9ispRs0PUff7A1uvBaGc7TWZwG/v23aw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-loader-circle": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.14.0.tgz",
-      "integrity": "sha512-I+rcgwbxwKGxLzVCGZ3qT4e/sK8CofTPzdCmh1BpNlKrWpuJ9NGgysrGs7V1IleJJxIXuzD+BBlIoGxuCwBJQg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.18.1.tgz",
+      "integrity": "sha512-YY/nyTYkbpjXctDdWj9PDokNGeR8YiXy/VU0EJcCWPR5J/RsoJHVQbY+VJ2sE99MKOGs5h2ejUi2CNYPErRihA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-menu-item": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.14.0.tgz",
-      "integrity": "sha512-8Pc68dJLwl7GrbGIRD7MpyMSBkuz8/CtzuLhygrFHK608crg5bBPC1+Zdt3VdkqDk7QZRd5rtL+pYgEJm87Q4A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.18.1.tgz",
+      "integrity": "sha512-0+I+9KTWtig+h9ZryysDcnKZ64Hqu3r9P5J2PoV4Zbkg2vqwrxs2gjgAGIM61YtmkxZ9amiX34eN9ZIFT1LU7w==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-loader-bar": "1.14.0",
-        "@umbraco-ui/uui-symbol-expand": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-loader-bar": "1.18.1",
+        "@umbraco-ui/uui-symbol-expand": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-modal": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.14.0.tgz",
-      "integrity": "sha512-3Ux1guj029PIcUn4nmPUU29Oqxq1HoRUib3lWoRRIgJ3F8WyGms+GEgCMj4v/LzIdezczqVtxKdOMcLIm2gvcQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.18.1.tgz",
+      "integrity": "sha512-mQnw+5c+t6HlKRxNksBVTnmHdhGCLGXSd9E3v1uHJAT43gnOBxGhTLvB+Hn+7/AG0W8qOpen5ANpzCEnsNIlAA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-pagination": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.14.0.tgz",
-      "integrity": "sha512-jP906bsiXOBpAdF/ZVi0hlRyR/+HX52ocjItlvMJWc2Xt4Fpzms7W90buYcG4hvz7g0snKy84JgTMup5vxf2iQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.18.1.tgz",
+      "integrity": "sha512-aS9gde50PIfhTr/mI510DqgHVjyuB+nG0eYdvXyoIShaSur5zLe8X+s7D0MwkE5EDQS8JNU+oNyc+2fEDKiSRg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-button": "1.14.0",
-        "@umbraco-ui/uui-button-group": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-button": "1.18.1",
+        "@umbraco-ui/uui-button-group": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-popover": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.14.0.tgz",
-      "integrity": "sha512-blMgYLRlEUon7vAQ6s1KE0hNBgyuMeI7ugxHCMDAFwgtHIh9VO2YfPAqlKBkofM72R9QZDbkCg1tOUuuF0yX1Q==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.18.1.tgz",
+      "integrity": "sha512-jqh1NCoFeKyWfwwBdictvL+IOV7C2nsLI2hmz3NJ0ZDWapBcdf2/L2/1u2HAD2vJ6xOiRzESV5pcT0tCjFH0lQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-popover-container": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.14.0.tgz",
-      "integrity": "sha512-1wG99PbKDdkzvV3W2avF5/zU7XLoxmui125EfKwCdDYuE5fsR1alBZHsdk6PvFXXpcbGaNJ/dWyWg+Ip687HeA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.18.1.tgz",
+      "integrity": "sha512-0pSjNV1Av4snoGbiARNrnws/fl0qer46N0/sMqgwoPL9HX1rChgp8sjFjA7t9MQEdcQ2O1TivyyggOY/aBOTWQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-scroll-container": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-progress-bar": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.14.0.tgz",
-      "integrity": "sha512-ImFS/QWWSZ9oExINb8thaQ6mexFpq62AbvZoVDzdBrje1pf9FErSs4u1XReS9iRtkE1kyGiyY302a4fAoKyMtQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.18.1.tgz",
+      "integrity": "sha512-zMWWLPQ1mZyAomb0aKF4toFZ4PcmpOqjcRmbqT8GVbrEMrMWw1oxl1Lnrsd3oPqs0GYAzVtv8SgADMcvgERVcA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-radio": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.14.0.tgz",
-      "integrity": "sha512-PbQ0SloYLJE6YUldwPU5MoBj+/zIQifNhaEYb2Ss2Ka7LFXFAZ9TvXr/INreh4zxI9DSeXirj41k3O+7fbB/Cg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.18.1.tgz",
+      "integrity": "sha512-IniLkaR4GEDyZAQivO+Yo3Ul5SCT2gMj1zWpKjrnqH8bMIdRpIbnbbHu80y3SteDnP31WdaR4aVbkNKXePnMuQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-range-slider": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.14.0.tgz",
-      "integrity": "sha512-ha798qXr/J3Kjd++eHBYdfqFSVKvSg9TWd+aAhAVj9rVb0Q8mbuinqUcWN9ZHukTNl7lG0/4HbTfM80Lm5V6TA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.18.1.tgz",
+      "integrity": "sha512-qShZrsuD/GIPpHeNPXTLkP2WuoOm1ez1YuNjyjq5ReyAKNpqqDaDmM1Ij8U/d/Qq85D9cKDc5qkMb2k7wqSmEQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-ref": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.14.0.tgz",
-      "integrity": "sha512-bjKcCLRxcu6HR+0kRrLpdit449FHhc16x1LZPncTtjAXN+kZYVmBiQ1QL2/W1l734vRm68nmHVuE5LB1Y2RuIw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.18.1.tgz",
+      "integrity": "sha512-bIn731uYv9rD7VvBrGbe8BDfyyeNFvfJS7r++3T2KTkmfek1O+D52UA1BejIcQd4dGZiMC2x0IS/zsLzrc2kqQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-list": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.14.0.tgz",
-      "integrity": "sha512-rVUldYm4FMAM3SJ8cCbvwdTm4LL9iz3LoFeTxXpfuo6STP+Y26kqR5z5hex6rUcX51se5yEp7PpQDO5bHHz5OA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.18.1.tgz",
+      "integrity": "sha512-nkMLUF7Z6CNV0tKsRDfVFblyRDM7wg+Aqnaedj9pdFUV1lH915n2/5abz+Mxn52J9VaFQm2jqPFleat0r1tcuA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.14.0.tgz",
-      "integrity": "sha512-d10iNjb5x3klPZzzt4AZqeGJ3xbqbaLc4NJb4lQ6C6+djLL+tsJf1MN1vC17dC/wPJ5B894iSBaha0fa8fVfMQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.18.1.tgz",
+      "integrity": "sha512-DfLjELWpUCeZ5d1Ff7K0u++kR1/49ZKy5U+G93qRu9NQjybyanhJw6JdXUUej8aI7XA0C+m2QZuqosVzGLBGng==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-icon": "1.14.0",
-        "@umbraco-ui/uui-ref": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-icon": "1.18.1",
+        "@umbraco-ui/uui-ref": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-data-type": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.14.0.tgz",
-      "integrity": "sha512-DcwR0qltykP1NHT8aRqbgQ4/PF2h64ehvBUpEeYg7U9/1xgpWlelkHlZ6CREzZUENaOFrpJzmhzbQWxYa7XKWA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.18.1.tgz",
+      "integrity": "sha512-0HP9IokgvHmh91Nm7dpeBhxIzMSJA7Otd15uHygoOWAlxcRhSLrOCUQc8GHlO9UZVbCwkECtkFF3FKafp6imZA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-ref-node": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-ref-node": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-document-type": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.14.0.tgz",
-      "integrity": "sha512-71A3vJa5SAZd6rTRaa5r/0fV+fr/Am4T5rZu8gdSfEw52ppkVNbg5iHqIwFKN2QDBzKI9GFSrjSVPmRJIsTNTQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.18.1.tgz",
+      "integrity": "sha512-kL0CZ7AwPVd2+ZHblQpPT+eSPTzX3JhIAinEsV203Td1C4dM9tL/x2m0nIvbH8KuHWusIjLvivFl6iXl9kBxRA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-ref-node": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-ref-node": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-form": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.14.0.tgz",
-      "integrity": "sha512-hVF6NtGqAZ0GRr28H2q2jOD7T4fTD837sJw7kJTLdzV5Oatu0rqWs4nmV6KpUCJjoUGYFWg+fKc5vvrF+gXXFA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.18.1.tgz",
+      "integrity": "sha512-DV8r2l2w35Q9wP7CkVFHQ6fuJzIlYUrxR9oZskd8tyB0xUu5qDBctapckBEEeRcr7xhdjsSxXQXckW6H39FDug==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-ref-node": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-ref-node": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-member": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.14.0.tgz",
-      "integrity": "sha512-Xy1mCgaPDLWnpXyfU1KgaEX+u04JXKnkbrj92d43k4HB30tbI/8BjwyYEaT3Phvs4fmUC0h4ege41Zu8aYfqDg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.18.1.tgz",
+      "integrity": "sha512-69onk+G3lh0dd6ivislLIIMEnSdHmbWDAt4f2grl7lsSUHFN3V308TuwjGg6ndtgdvqyLDqsJ3g1rTnEmtsKkw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-ref-node": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-ref-node": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-package": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.14.0.tgz",
-      "integrity": "sha512-MNF0n9nlC6W7Ove9fm7+YwhWwEL5+nUmhYZySEb3YAwjOXHDgL9hHS0gmT1YXxu+66RtBXdqUkZbfI2AVKv7qw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.18.1.tgz",
+      "integrity": "sha512-GNfSPp5Qi5sZT2QFrCUl9JIJ2Qj4zoi+ooKkUgKRGlPMwqF8VOLGAvoBtNrGq/jFKrqGCou4e7MQxD9QlA9KRg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-ref-node": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-ref-node": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-user": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.14.0.tgz",
-      "integrity": "sha512-AFycox1NtGnhVtGgJ3Sg0fCAUlOf38V7S2KPrFubAFmjbxcddWqlMVWzxTcUbUDE2TL5KHnU/JCUxf4BQO1pUw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.18.1.tgz",
+      "integrity": "sha512-wdY7TDK9ahFBhC0lHQVKUh8UuXwnSc2/LSKLwiaveGlDyeixInR03iKqS7Mif2kt0vVYlqJE2xYtUMQmuNofGg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-ref-node": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-ref-node": "1.18.1"
+      }
+    },
+    "node_modules/@umbraco-ui/uui-responsive-container": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-responsive-container/-/uui-responsive-container-1.18.1.tgz",
+      "integrity": "sha512-wkitm+1ane96OUkvY7yB7gD8gX2LO8uKRQMcdm164ptBJG+V2vt2K6Yx3W5uFhDSqQ2c9rkYAKREOjg35KnvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-button": "1.18.1",
+        "@umbraco-ui/uui-button-group": "1.18.1",
+        "@umbraco-ui/uui-popover-container": "1.18.1",
+        "@umbraco-ui/uui-symbol-more": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-scroll-container": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.14.0.tgz",
-      "integrity": "sha512-N+jYDLTCmo5vC1Mutv/d/mWMivkbWXI1AWM20i7wDQ3U8R6VsbA4Rr7Ne8V9jSnOrgQY9PHrTE2OI99S0bFrnw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.18.1.tgz",
+      "integrity": "sha512-FXFViw8nmi+mshQQAYTz3jRPBpz5qcIuR1N2O8+6ERXHhdKlcuVDS3agfrMGmy/Mtc6/k3xaX30smy9zNYxP9w==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-select": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.14.0.tgz",
-      "integrity": "sha512-/hTUiJ38/gpEf4pk7AWauy/i4o+DYkJR9CpdkL8oyjjwjkmJAVL817v4sXUcTvuaYYVrVqBY1M7U3FgEumKHVw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.18.1.tgz",
+      "integrity": "sha512-QSjsKd9Cij7kwW8MJ6RDH4IkpRFDZECxlCmWcoHqvWWH7Alu0ZbgYN/fR+as45E2EbhcBDjLl/QdNik9f6tYBQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-slider": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.14.0.tgz",
-      "integrity": "sha512-biiJ7+aJnkfaPcNF4fuIIGfEmvmTXoOmI56BZN4ICRo1+wntVkfY64hjGTQ2gPV/d26eK1FNyUFpRl8leIxjVA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.18.1.tgz",
+      "integrity": "sha512-7yUnEEOpLPm0pJBsjKTMa8ftahYYqJ26NsbgpCwwHK/+OuElYis6dcFiNugrhZiQFiw5Y7SgVHcQrakjptGf1w==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-expand": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.14.0.tgz",
-      "integrity": "sha512-8cXPlHmIoajexztcHKGdTrmbp+NR4O0Le+EtQrRMqf6S8apbw7SNy98h3CeSb6Gq2ZTXdXxzZnCtyo+znxpFHA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.18.1.tgz",
+      "integrity": "sha512-46/xMn1d0cqhrn8gOiWHea0qDIGUbxZNP46w2RYlYnweyAzIGJ6yZRn/KzFosPt144+rmrJirYbg7touCvo84Q==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.14.0.tgz",
-      "integrity": "sha512-vWx6C/0xT+SUk3LTeqrzbS4P6YXPzN0kqqnUH7riHACYNZxmpAgB8EVU0MzlMdW/TpiMcapw0/KHYuMtBZ8Nkw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.18.1.tgz",
+      "integrity": "sha512-7iLPRrzCGrH56uJ8GDQJUuP+fGWzQtHjPqFIzjmmGcXgCnUte4PvbRG5ZpjBVxTbkGYXBYI1bwMHKiL0k9l7MA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file-dropzone": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.14.0.tgz",
-      "integrity": "sha512-AAb/Cv/INzjonxc4fDR1n0YMs2hO+O+fYtsW9VyAUxqLHnhxNFufwPU80v1Y0nNnKuaNlSAdGwM/4QJujwhj3w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.18.1.tgz",
+      "integrity": "sha512-ZAmmeh922FWo9EQXVeN0cgi0R9BwA4vuOc8rBr80EkJ/BuEJda9rE+rGwW3WAf2H6cfJ0RUC8syVS7oO+3DOUg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file-thumbnail": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.14.0.tgz",
-      "integrity": "sha512-BBQKo03UVTPq6MO6GVDPv40w3Nizy8LRKQ6quNuhB0UcrWkqOAoJEMX/afX17oGtCoONN/Zq54mmXWgHD8yo1Q==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.18.1.tgz",
+      "integrity": "sha512-fxxNBp+9K7TMds2LIIq4nPPJbgEr/+JU3XG19t6Ll3qGJuF7z6puZ3dHTdeVHOcqbZULtxkSFfDTFCPaRbM39A==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-folder": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.14.0.tgz",
-      "integrity": "sha512-Z+Kcdk2QyuLf+hKNTacdM6jeNo+wexZ0ktUPbVHJUjYaHuyzqNVV0Du8NJyFBMwyiomV9xLKxQi0YeI/aDg+Cg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.18.1.tgz",
+      "integrity": "sha512-EiPaUOoHK+RH0A3Paj5kIvB4fkgRKSZxg6ijs9q3mkQ4zZOxzYLZjQCsdTOfX8vG9M6ML55kFmevKO2JqYDDCw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-lock": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.14.0.tgz",
-      "integrity": "sha512-dLcc1TkD541ikC+iOEguJmXsJYphqBwEmt2fqVJEDYddmGUf1ZlUNJSjkamU8vaER6NgNIhmqByU0Lv2SdDrjQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.18.1.tgz",
+      "integrity": "sha512-UkRI0kKGSRxopAkLYF5OgaaivW+rrLI8ZTet8YDWSd4oNbfjNfHnNDrGET5tTBbWPAz5jP+Wh+rV7foB9dNR8g==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-more": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.14.0.tgz",
-      "integrity": "sha512-HgelD3iF2YMRrCumw8YqeVW/OsByGMWF1ILk8aylyS+4faIEKhnKIpLlw0WovFBYJQpWilcm/JtMqBqa6DfMvg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.18.1.tgz",
+      "integrity": "sha512-maBxUrIkBtyh6xBy3xVvLiy4o4tRo7+ZZPCFpkCILX+tZdsAs6jH63BzScdN6R+G+jlzwTYR88paEVTak2GNgQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-sort": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.14.0.tgz",
-      "integrity": "sha512-cXahfWqCZuu1AOQyrycTmKgZXzBq8v+cqLsEeE929ZokVD35AsTXkLbo6kLN+zVRXAz5kNyaERrfS8yLoZFtWA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.18.1.tgz",
+      "integrity": "sha512-OfqGTLPE9himdFLg7L4e7YD9vVR8zHhCBMxxlNlow49psDuI1q6xDZBag3MTy2pcGwUl6ssphmawGyegkDaHcA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-table": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.14.0.tgz",
-      "integrity": "sha512-4ko7jaoH24qLnlwo6jWAuphmkcNL/7RXcDOSgW8aBc0x3nXG2Ufk4PQi0z+k614eDW6+seMZASAsnMx94XhLEQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.18.1.tgz",
+      "integrity": "sha512-6H8UvMNioU8KpmG6H6R+OYChDisr4wMKsujAhMp68TYSdfehBnHt204bu1Z4aD1WWiMk8lwzEhfIkwi9aFOFdA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-tabs": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.14.0.tgz",
-      "integrity": "sha512-m7OEIFK9YD2z7PgD78+U0uFacob/9DqN4nlZXxOkaj/tIxcBbWDXCqRnVBkhkxJKocs6NBYaGi2XHBq9F7/S/w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.18.1.tgz",
+      "integrity": "sha512-As41TkTcrYRU0WH/gcVvi2zaAIN78ew70S9RRvsPJIRqX4yGFoE08Q+7PaFd7a2ZatCybjigfAk9bTqmDLIvQg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-button": "1.14.0",
-        "@umbraco-ui/uui-popover-container": "1.14.0",
-        "@umbraco-ui/uui-symbol-more": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-button": "1.18.1",
+        "@umbraco-ui/uui-popover-container": "1.18.1",
+        "@umbraco-ui/uui-symbol-more": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-tag": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.14.0.tgz",
-      "integrity": "sha512-CphycjqzlUnMA+eEgJCCLKtmsCn5ileGPDn5ei427dc5P5wOEU6aGKqeAGMivP6db4UhUMjh3g0xXfQCKbqEaA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.18.1.tgz",
+      "integrity": "sha512-L1II3i45BAZo+f40ve7dTFCi5pcjWC6iRt1smWy0x9Mp6X0GfLtKVEtHsIlo929at7Py2S0RtOLKUf9jP6UwsQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-textarea": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.14.0.tgz",
-      "integrity": "sha512-l/hyV78IQn+Akb4UA0AtOTsdYJgCun7eC+i0vaOeNANXrO/B0Dhr2yembO0/mf/u2RxIFeOSsW8GUYixrIxSPw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.18.1.tgz",
+      "integrity": "sha512-nh8fzZ6aKCbmPC196x8ooVBgfuPZTshJf/ipupYMwUVuuk+UgYYzroCki/PvpglbFDYnvedZT56zYjOwqiIcAQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.14.0.tgz",
-      "integrity": "sha512-5pb4miAkdgoURoTQGvXQZoUHWIR4tgdUe78hPr2et3xSNw+N0Y/LHlDX1Bo9FBOKEvtFT6YHM0nqOIjW9/RpKw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.18.1.tgz",
+      "integrity": "sha512-dB2rPSIRury/+/qgFGn3/e0StAyZL6OCJQXr2c3Tfw51aOf526TLZ2J3luN8MdwV7qZAHDfKZpLxkJzj5CczWw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-button": "1.14.0",
-        "@umbraco-ui/uui-css": "1.14.0",
-        "@umbraco-ui/uui-icon": "1.14.0",
-        "@umbraco-ui/uui-icon-registry-essential": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-button": "1.18.1",
+        "@umbraco-ui/uui-css": "1.18.1",
+        "@umbraco-ui/uui-icon": "1.18.1",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification-container": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.14.0.tgz",
-      "integrity": "sha512-5ai853OExMOFrKTrAgvx4OkRNJY8gfIA3UmLBQSVE4E065I0xW4F+L9A3foEU4so2z01OIwvJ53RRk7JriohTg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.18.1.tgz",
+      "integrity": "sha512-syKVAgptFHVLWnJXV5v1tsk88a8Va1NO+42rQL5G6T7FhmCA/hPl9uHPmUnAhPsQ+0KM0U6X+xITz4PEjz8krw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-toast-notification": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-toast-notification": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification-layout": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.14.0.tgz",
-      "integrity": "sha512-8WaiSNLB8NoKJMRQCqFh+KkhjOStXcJ+yLJJR/AM6HF6Pc0tYl+R3zM4LY9WJjQQEOXENcTUPMURJSwpJ2fsGA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.18.1.tgz",
+      "integrity": "sha512-mPOJ0+/W5M+umzzd7s7w/CiqbW0JHfL9GzPyOITU1vknMJAj9f4PwzrM5fLCof3ZzntezPPEravM3CocSdRnIQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-css": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-css": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-toggle": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.14.0.tgz",
-      "integrity": "sha512-s8//Y2LAqDQ3h4C3PA9yJcVXF2H6gnv2NzMZ22KotJQT9+yhhR3UrOlndOZKkWqKtDxwSLEp9EmyITgDdEoT3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.18.1.tgz",
+      "integrity": "sha512-YVELjzzArB7fBZB4aAEXFeMZT9hGAQMoHjRFb9NR0Z37Mw29YkF0CLg2fSVJXyI+086Gvusw/KHEp7my9sl+Ig==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0",
-        "@umbraco-ui/uui-boolean-input": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1",
+        "@umbraco-ui/uui-boolean-input": "1.18.1"
       }
     },
     "node_modules/@umbraco-ui/uui-visually-hidden": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.14.0.tgz",
-      "integrity": "sha512-wGbMiw+UuMYayMDBau5dD2B3HX2tFPlnOftvD9Z+FNKnGnU5e/V+QInCYy7FlywBQ5fDpfKcXseud/kONGRmsA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.18.1.tgz",
+      "integrity": "sha512-eIwCQ8rVHszJv1e8LQLAFBajdS9rfq5m+rxEhMQfTzW7L2b9DUxwXcePZyDzLqXYFujgkxMW72Wv0zxSiTRxIw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.14.0"
+        "@umbraco-ui/uui-base": "1.18.1"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
       },
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=6.5"
       }
     },
     "node_modules/ansi-colors": {
@@ -2402,7 +2263,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -2421,26 +2283,27 @@
       }
     },
     "node_modules/c12": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-2.0.1.tgz",
-      "integrity": "sha512-Z4JgsKXHG37C6PYUtIxCfLJZvo6FyhHJoClwwb9ftUkLpPSkuYqn6Tr+vnaN8hymm0kIbcg6Ey3kv/Q71k5w/A==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.1",
-        "confbox": "^0.1.7",
-        "defu": "^6.1.4",
-        "dotenv": "^16.4.5",
-        "giget": "^1.2.3",
-        "jiti": "^2.3.0",
-        "mlly": "^1.7.1",
-        "ohash": "^1.1.4",
-        "pathe": "^1.1.2",
-        "perfect-debounce": "^1.0.0",
-        "pkg-types": "^1.2.0",
-        "rc9": "^2.1.2"
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
       },
       "peerDependencies": {
-        "magicast": "^0.3.5"
+        "magicast": "*"
       },
       "peerDependenciesMeta": {
         "magicast": {
@@ -2449,9 +2312,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
-      "integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2462,36 +2325,19 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "dev": true,
-      "dependencies": {
-        "consola": "^3.2.3"
       }
     },
     "node_modules/color-support": {
@@ -2509,55 +2355,42 @@
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/commander": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
-      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true
-    },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
-    },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.1"
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
       },
       "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
       },
       "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -2565,6 +2398,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2579,14 +2413,15 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/default-browser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2601,9 +2436,9 @@
       }
     },
     "node_modules/default-browser-id": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2627,42 +2462,57 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -2675,79 +2525,47 @@
       "resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-3.0.2.tgz",
       "integrity": "sha512-uB0/Qube3lkwh8SmkTnGIyUgJ9YdqVSzIoHMRCEQjAbD4Y5UzsVbch1tIxjTgUe5k3gy1U0ZMKMJ90A81lqwig==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "node": ">=6"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -2772,6 +2590,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -2780,40 +2599,29 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "dev": true,
+      "license": "Unlicense",
+      "peer": true,
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/fsevents": {
@@ -2822,6 +2630,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2830,49 +2639,27 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/giget": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-1.2.5.tgz",
-      "integrity": "sha512-r1ekGw/Bgpi3HLV3h1MRBIlSAdHoIMklpaQ3OQLFcRw9PwAj2rqigvIbg+dBUI51OxVI2jsEtDywDBjSiuf7Ug==",
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.5.4",
-        "pathe": "^2.0.3",
-        "tar": "^6.2.1"
+        "resolve-pkg-maps": "^1.0.0"
       },
-      "bin": {
-        "giget": "dist/cli.mjs"
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/giget/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+    "node_modules/giget": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
+      "license": "MIT",
       "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/is-docker": {
@@ -2886,6 +2673,19 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2911,9 +2711,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2930,22 +2730,34 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2954,28 +2766,281 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
-      "peer": true,
+      "license": "MPL-2.0",
       "dependencies": {
-        "uc.micro": "^2.0.0"
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/linkifyjs": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.1.tgz",
-      "integrity": "sha512-DRSlB9DKVW04c4SUdGvKK5FR6be45lTU9M76JnngqPeeGDqPwYc0zdUErtsNVMtxPXgUWV4HbXbnC4sNyBxkYg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/lit": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
-      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -2984,57 +3049,83 @@
       }
     },
     "node_modules/lit-element": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.0.tgz",
-      "integrity": "sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
         "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.0.tgz",
-      "integrity": "sha512-RHoswrFAxY2d8Cf2mm4OZ1DgzCoBKUKSPvA1fhtSELxUERq2aQQ2h05pO9j81gS1o7RIRJ+CePLogfyahwmynw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "dev": true,
+      "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "dev": true,
+      "license": "MIT",
       "peer": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -3043,97 +3134,10 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mlly": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.14.0",
-        "pathe": "^2.0.1",
-        "pkg-types": "^1.3.0",
-        "ufo": "^1.5.4"
-      }
-    },
-    "node_modules/mlly/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -3141,18 +3145,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -3170,6 +3169,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -3179,6 +3179,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -3192,58 +3193,29 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
-      "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
-      "dev": true
-    },
-    "node_modules/nypm": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.5.4.tgz",
-      "integrity": "sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==",
-      "dev": true,
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "tinyexec": "^0.3.2",
-        "ufo": "^1.5.4"
-      },
-      "bin": {
-        "nypm": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": "^14.16.0 || >=16.10.0"
-      }
-    },
-    "node_modules/nypm/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
-    },
     "node_modules/ohash": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
-      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
-      "dev": true
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/open": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3254,6 +3226,7 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/path-key": {
@@ -3261,33 +3234,38 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -3296,26 +3274,21 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
       }
     },
-    "node_modules/pkg-types/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
-    },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -3331,8 +3304,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3340,24 +3314,28 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prosemirror-changeset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.3.1.tgz",
-      "integrity": "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==",
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/prosemirror-collab": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
       }
     },
     "node_modules/prosemirror-commands": {
@@ -3365,6 +3343,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
       "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
@@ -3373,10 +3352,11 @@
       }
     },
     "node_modules/prosemirror-dropcursor": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
-      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+      "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
@@ -3385,10 +3365,11 @@
       }
     },
     "node_modules/prosemirror-gapcursor": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
-      "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
@@ -3398,10 +3379,11 @@
       }
     },
     "node_modules/prosemirror-history": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
-      "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.2.2",
@@ -3411,10 +3393,11 @@
       }
     },
     "node_modules/prosemirror-inputrules": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.0.tgz",
-      "integrity": "sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
@@ -3426,55 +3409,22 @@
       "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
       "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
       }
     },
-    "node_modules/prosemirror-markdown": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
-      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/markdown-it": "^14.0.0",
-        "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.25.0"
-      }
-    },
-    "node_modules/prosemirror-menu": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.5.tgz",
-      "integrity": "sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "crelt": "^1.0.0",
-        "prosemirror-commands": "^1.0.0",
-        "prosemirror-history": "^1.0.0",
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-model": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.1.tgz",
-      "integrity": "sha512-AUvbm7qqmpZa5d9fPKMvH1Q5bqYQvAZWOGRvxsB6iFLyycvC9MwNemNVjHVrWgjaoxAfY8XVg7DbvQ/qxvI9Eg==",
+      "version": "1.25.10",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.10.tgz",
+      "integrity": "sha512-9n6rH4DbJU1eH4SxLt6Y0HhJIo6cZsb7DJ/30uob1hOKPeO6TAaMWI2tc7kwR92BjfPOU2fFHWbZLovLi3XQfA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
-      }
-    },
-    "node_modules/prosemirror-schema-basic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.25.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -3482,6 +3432,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
       "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
@@ -3490,10 +3441,11 @@
       }
     },
     "node_modules/prosemirror-state": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
-      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
@@ -3502,127 +3454,152 @@
       }
     },
     "node_modules/prosemirror-tables": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.7.1.tgz",
-      "integrity": "sha512-eRQ97Bf+i9Eby99QbyAiyov43iOKgWa7QCGly+lrDt7efZ1v8NWolhXiB43hSDGIXT1UXgbs4KJN3a06FGpr1Q==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-model": "^1.25.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-transform": "^1.10.3",
-        "prosemirror-view": "^1.39.1"
-      }
-    },
-    "node_modules/prosemirror-trailing-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@remirror/core-constants": "3.0.0",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.22.1",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.33.8"
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.4.tgz",
-      "integrity": "sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.21.0"
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.40.0.tgz",
-      "integrity": "sha512-2G3svX0Cr1sJjkD/DYWSe3cfV5VPVTBOxI9XQEGWJDFEpsZb/gh4MV29ctv+OJx2RFX4BLt09i+6zaGM/ldkCw==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.0.tgz",
+      "integrity": "sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "prosemirror-model": "^1.20.0",
+        "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
     },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/rc9": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
-      "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.44.1",
-        "@rollup/rollup-android-arm64": "4.44.1",
-        "@rollup/rollup-darwin-arm64": "4.44.1",
-        "@rollup/rollup-darwin-x64": "4.44.1",
-        "@rollup/rollup-freebsd-arm64": "4.44.1",
-        "@rollup/rollup-freebsd-x64": "4.44.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.44.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.44.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.44.1",
-        "@rollup/rollup-linux-arm64-musl": "4.44.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.44.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.44.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.44.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.44.1",
-        "@rollup/rollup-linux-x64-gnu": "4.44.1",
-        "@rollup/rollup-linux-x64-musl": "4.44.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.44.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.44.1",
-        "@rollup/rollup-win32-x64-msvc": "4.44.1",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/rope-sequence": {
@@ -3630,12 +3607,13 @@
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/run-applescript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3650,15 +3628,16 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3668,11 +3647,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -3685,17 +3673,9 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -3703,41 +3683,20 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true
-    },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3746,18 +3705,44 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3766,64 +3751,62 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
-      "peer": true
-    },
-    "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-      "dev": true
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
+      "license": "MIT",
+      "peer": true,
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "peer": true,
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -3832,14 +3815,15 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -3848,13 +3832,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -3885,6 +3872,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/web-streams-polyfill": {
@@ -3892,8 +3880,29 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -3901,6 +3910,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3911,17 +3921,45 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/src/Integrations.Umbraco/Client/package.json
+++ b/src/Integrations.Umbraco/Client/package.json
@@ -9,13 +9,13 @@
     "generate-client": "node scripts/generate-openapi.js https://localhost:44381/umbraco/swagger/relewisedashboard/swagger.json"
   },
   "devDependencies": {
-    "@hey-api/client-fetch": "^0.10.0",
-    "@hey-api/openapi-ts": "0.80.5",
+    "@hey-api/client-fetch": "^0.13.1",
+    "@hey-api/openapi-ts": "0.99.0",
     "@umbraco-cms/backoffice": "^*",
-    "chalk": "5.5.0",
-    "cross-env": "^7.0.3",
+    "chalk": "5.6.2",
+    "cross-env": "^10.1.0",
     "node-fetch": "^3.3.2",
-    "typescript": "^5.8.3",
-    "vite": "^6.3.4"
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3"
   }
 }

--- a/src/Integrations.Umbraco/Integrations.Umbraco.csproj
+++ b/src/Integrations.Umbraco/Integrations.Umbraco.csproj
@@ -11,7 +11,7 @@
 		<Title>Relewise integration for Umbraco</Title>
 		<Description>An extension for Umbraco CMS allowing easy content export to Relewise</Description>
 		<PackageIcon>logo.png</PackageIcon>
-		<PackageTags>Relewise;Umbraco;Umbraco-v9;Umbraco-v10;Umbraco-v11;Umbraco-v12;Umbraco-v13;Umbraco-v15;Umbraco-v16;Umbraco-v17;Recommendations;Search;SearchEngine;Personalization;Recommender;umbraco-marketplace;Shoppertainment;retail-media;display-ads</PackageTags>
+		<PackageTags>Relewise;Umbraco;Umbraco-v9;Umbraco-v10;Umbraco-v11;Umbraco-v12;Umbraco-v13;Umbraco-v15;Umbraco-v16;Umbraco-v17;Umbraco-v18;Recommendations;Search;SearchEngine;Personalization;Recommender;umbraco-marketplace;Shoppertainment;retail-media;display-ads</PackageTags>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -35,11 +35,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<!--Version 17-->
-		<PackageReference Include="Umbraco.Cms.Web.Common" Version="[17.0.0,18)" />
-		<PackageReference Include="Umbraco.Cms.Web.Website" Version="[17.0.0,18)" />
-		<PackageReference Include="Umbraco.Cms.Api.Common" Version="[17.0.0,18)" />
-		<PackageReference Include="Umbraco.Cms.Api.Management" Version="[17.0.0,18)" />
+		<!--Version 17-18-->
+		<PackageReference Include="Umbraco.Cms.Web.Common" Version="[17.0.0,19)" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" Version="[17.0.0,19)" />
+		<PackageReference Include="Umbraco.Cms.Api.Common" Version="[17.0.0,19)" />
+		<PackageReference Include="Umbraco.Cms.Api.Management" Version="[17.0.0,19)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Integrations.Umbraco/Integrations.Umbraco.csproj
+++ b/src/Integrations.Umbraco/Integrations.Umbraco.csproj
@@ -30,16 +30,16 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Relewise.Client" Version="[1.96.0, 2)" />
-		<PackageReference Include="Relewise.Client.Extensions" Version="[1.4.1, 2)" />
+		<PackageReference Include="Relewise.Client" Version="[1.303.0, 2)" />
+		<PackageReference Include="Relewise.Client.Extensions" Version="[1.7.0, 2)" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<!--Version 17-->
-		<PackageReference Include="Umbraco.Cms.Web.Common" Version="[17.0.0,18)" />
-		<PackageReference Include="Umbraco.Cms.Web.Website" Version="[17.0.0,18)" />
-		<PackageReference Include="Umbraco.Cms.Api.Common" Version="[17.0.0,18)" />
-		<PackageReference Include="Umbraco.Cms.Api.Management" Version="[17.0.0,18)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" Version="[17.5.3,18)" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" Version="[17.5.3,18)" />
+		<PackageReference Include="Umbraco.Cms.Api.Common" Version="[17.5.3,18)" />
+		<PackageReference Include="Umbraco.Cms.Api.Management" Version="[17.5.3,18)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Integrations.Umbraco/Integrations.Umbraco.csproj
+++ b/src/Integrations.Umbraco/Integrations.Umbraco.csproj
@@ -30,16 +30,16 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Relewise.Client" Version="[1.303.0, 2)" />
-		<PackageReference Include="Relewise.Client.Extensions" Version="[1.7.0, 2)" />
+		<PackageReference Include="Relewise.Client" Version="[1.96.0, 2)" />
+		<PackageReference Include="Relewise.Client.Extensions" Version="[1.4.1, 2)" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<!--Version 17-->
-		<PackageReference Include="Umbraco.Cms.Web.Common" Version="[17.5.3,18)" />
-		<PackageReference Include="Umbraco.Cms.Web.Website" Version="[17.5.3,18)" />
-		<PackageReference Include="Umbraco.Cms.Api.Common" Version="[17.5.3,18)" />
-		<PackageReference Include="Umbraco.Cms.Api.Management" Version="[17.5.3,18)" />
+		<PackageReference Include="Umbraco.Cms.Web.Common" Version="[17.0.0,18)" />
+		<PackageReference Include="Umbraco.Cms.Web.Website" Version="[17.0.0,18)" />
+		<PackageReference Include="Umbraco.Cms.Api.Common" Version="[17.0.0,18)" />
+		<PackageReference Include="Umbraco.Cms.Api.Management" Version="[17.0.0,18)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/umbraco-marketplace.json
+++ b/umbraco-marketplace.json
@@ -1,7 +1,7 @@
 {
   "Title": "Relewise integration for Umbraco",
   "Category": "Search",
-  "Tags": ["Relewise", "Recommendations", "Search", "recommendation-engine", "search-engine", "up-sell-prediction", "personalization", "cross-sell-prediction"],
+  "Tags": ["Relewise", "Recommendations", "Search", "Umbraco-v18", "recommendation-engine", "search-engine", "up-sell-prediction", "personalization", "cross-sell-prediction"],
   "LicenseTypes": [ "Free" ],
   "PackageType": "Package",
   "Description": "The extension that has been developed to facilitate a seamless and hassle-free exporting of content to Relewise, which enables users to effectively manage their content export in a more efficient and streamlined manner."


### PR DESCRIPTION
https://trello.com/c/nO2BleJM/21024-umbraco-update-dependencies

## Summary
- Upgraded package project NuGet lower bounds for Relewise.Client to 1.303.0 and Relewise.Client.Extensions to 1.7.0 while preserving [x, 2) ranges.
- Upgraded Umbraco 17 dependencies to 17.5.3 across package ranges and sample exact package references.
- Upgraded direct npm dev dependencies and regenerated src/Integrations.Umbraco/Client/package-lock.json from a clean install state.
- Preserved @umbraco-cms/backoffice as ^*; clean lockfile resolution now installs 17.5.3.

## Validation
- dotnet restore Relewise.Integrations.Umbraco.sln: passed with existing NU1903 warnings for transitive Microsoft.OpenApi 2.4.1 and SQLitePCLRaw.lib.e_sqlite3 2.1.11 in the sample project.
- dotnet build Relewise.Integrations.Umbraco.sln: passed with the same NU1903 warnings.
- 
pm ci in src/Integrations.Umbraco/Client: passed.
- 
pm run build in src/Integrations.Umbraco/Client: passed.

## Notes
- Umbraco 18.0.2 remains intentionally skipped because the package project compatibility range is [17.5.3,18) and this task did not request an Umbraco major upgrade.
- Moved sample AppClientFiles enumeration into the copy target so hashed Vite output is collected after the referenced client build refreshes assets.
- No test projects were found in the solution.
- 
pm audit --audit-level=moderate reports a remaining moderate DOMPurify issue through @umbraco-cms/backoffice/monaco-editor.
